### PR TITLE
Abstract Types for Primitives

### DIFF
--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -65,6 +65,8 @@ export GLTriangle
 export GLQuad
 
 # Some primitives
+export GeometryPrimitive
+
 export Cube
 export Circle                   # Simple circle object
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -50,32 +50,33 @@ immutable AABB{T}
   max::Vector3{T}
 end
 
-immutable Cube{T}
+abstract GeometryPrimitive #abstract type for primitives
+immutable Cube{T} <: GeometryPrimitive
   origin::Vector3{T}
   width::Vector3{T}
 end
-immutable Circle{T}
+immutable Circle{T} <: GeometryPrimitive
     center::Point2{T}
     r::T
 end
-immutable Sphere{T}
+immutable Sphere{T} <: GeometryPrimitive
     center::Point3{T}
     r::T
 end
-immutable Rectangle{T}
+immutable Rectangle{T} <: GeometryPrimitive
     x::T
     y::T
     w::T
     h::T
 end
 
-immutable Quad{T}
+immutable Quad{T} <: GeometryPrimitive
   downleft::Vector3{T}
   width::Vector3{T}
   height::Vector3{T}
 end
 
-immutable Pyramid{T}
+immutable Pyramid{T} <: GeometryPrimitive
   middle::Point3{T}
   length::T
   width::T

--- a/src/types.jl
+++ b/src/types.jl
@@ -82,20 +82,20 @@ immutable Pyramid{T} <: GeometryPrimitive
   width::T
 end
 
-type MCube{T}
+type MCube{T} <: GeometryPrimitive
   min::MVector3{T}
   max::MVector3{T}
 end
 
-type MCircle{T}
+type MCircle{T} <: GeometryPrimitive
     center::MPoint2{T}
     r::T
 end
-type MSphere{T}
+type MSphere{T} <: GeometryPrimitive
     center::MPoint3{T}
     r::T
 end
-type MRectangle{T}
+type MRectangle{T} <: GeometryPrimitive
     x::T
     y::T
     w::T


### PR DESCRIPTION
Hey Simon,

As per our discussion at https://github.com/rohitvarkey/Compose3D.jl/issues/2, I was trying to make the primitives I'm using GeometryType primitives. For this, I would like to have an abstract type, say "GeometryPrimitive", as a super type for all the primitives. This will help me make sure that I'll be creating geometries in Compose3D only for these types rather than all FixedSizeArrays. 

I was able to convert the sphere primitive I was using earlier to the GeometryType.Sphere type you have after these changes to GeometryTypes. The working code is at https://github.com/rohitvarkey/Compose3D.jl/tree/geometryTypes. 

I'm guessing this will help others also with similar intentions to identify geometry primitives also!
 
Regards,
Rohit.