### PR TITLE
Face{N} -> Face{2} via Tuple{Face{2}}(f) for #20

### DIFF
--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -42,6 +42,8 @@ include("setops.jl")
 include("points.jl")
 include("display.jl")
 include("slice.jl")
+include("decompose.jl")
+include("deprecated.jl")
 
 export AABB,
        AbsoluteRectangle,
@@ -49,6 +51,7 @@ export AABB,
        AbstractSimplex,
        Circle,
        Cube,
+       decompose,
        Face,
        GLFace,
        GLMesh2D,

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -24,6 +24,54 @@ Extract all line segments in a Face.
                                         f[$(i+1)]+$(-O2+O1))) for i = 1:N-1])
     # connect vertices N and 1
     push!(v.args, :(Face{2,$FT1,$O1}(f[$(N)]+$(-O2+O1),
-                                     f[$(1)]+$(-O2+O1))))
+                                     f[$(1)]+$(-O2+O1)))) # not enough dollars
     v
+end
+
+function decompose{T}(::Type{Point{3,T}}, rect::HyperRectangle{3, T})
+       (Point{3, T}(rect.minimum[1],rect.minimum[2],rect.minimum[3]),
+        Point{3, T}(rect.minimum[1],rect.minimum[2],rect.maximum[3]),
+        Point{3, T}(rect.minimum[1],rect.maximum[2],rect.minimum[3]),
+        Point{3, T}(rect.minimum[1],rect.maximum[2],rect.maximum[3]),
+        Point{3, T}(rect.maximum[1],rect.minimum[2],rect.minimum[3]),
+        Point{3, T}(rect.maximum[1],rect.minimum[2],rect.maximum[3]),
+        Point{3, T}(rect.maximum[1],rect.maximum[2],rect.minimum[3]),
+        Point{3, T}(rect.maximum[1],rect.maximum[2],rect.maximum[3]))
+end
+
+function decompose{T}(::Type{Point{2,T}}, rect::HyperRectangle{2, T})
+       (Point{2,T}(rect.minimum[1], rect.minimum[2]),
+        Point{2, T}(rect.minimum[1], rect.maximum[2]),
+        Point{2, T}(rect.maximum[1], rect.minimum[2]),
+        Point{2,T}(rect.maximum[1], rect.maximum[2]))
+end
+
+function decompose{PT}(T::Type{Point{2, PT}},r::Rectangle)
+   T[T(r.x, r.y),
+    T(r.x, r.y + r.h),
+    T(r.x + r.w, r.y + r.h),
+    T(r.x + r.w, r.y)]
+end
+
+function decompose{PT}(T::Type{Point{3, PT}},p::Pyramid)
+    leftup   = T(-p.width , p.width, PT(0)) / 2f0
+    leftdown = T(-p.width, -p.width, PT(0)) / 2f0
+    tip = T(p.middle + T(PT(0),PT(0),p.length))
+    lu  = T(p.middle + leftup)
+    ld  = T(p.middle + leftdown)
+    ru  = T(p.middle - leftdown)
+    rd  = T(p.middle - leftup)
+    T[tip, rd, ru,
+        tip, ru, lu,
+        tip, lu, ld,
+        tip, ld, rd,
+        rd,  ru, lu,
+        lu,  ld, rd]
+end
+
+function decompose{ET}(T::Type{Point{3, ET}}, q::Quad)
+   T[q.downleft,
+    q.downleft + q.height,
+    q.downleft + q.width + q.height,
+    q.downleft + q.width]
 end

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -1,0 +1,29 @@
+"""
+Triangulate an N-Face into a tuple of triangular faces.
+"""
+@generated function decompose{N, FT1, FT2, O1, O2}(::Type{Face{3, FT1, O1}},
+                                       f::Face{N, FT2, O2})
+    @assert 3 <= N # other wise degenerate
+
+    v = Expr(:tuple)
+    append!(v.args, [:(Face{3,$FT1,$O1}(f[1]+$(-O2+O1),
+                                        f[$(i-1)]+$(-O2+O1),
+                                        f[$(i)]+$(-O2+O1))) for i = 3:N])
+    v
+end
+
+"""
+Extract all line segments in a Face.
+"""
+@generated function decompose{N, FT1, FT2, O1, O2}(::Type{Face{2, FT1, O1}},
+                                       f::Face{N, FT2, O2})
+    @assert 2 <= N # other wise degenerate
+
+    v = Expr(:tuple)
+    append!(v.args, [:(Face{2,$FT1,$O1}(f[$(i)]+$(-O2+O1),
+                                        f[$(i+1)]+$(-O2+O1))) for i = 1:N-1])
+    # connect vertices N and 1
+    push!(v.args, :(Face{2,$FT1,$O1}(f[$(N)]+$(-O2+O1),
+                                     f[$(1)]+$(-O2+O1))))
+    v
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,1 +1,14 @@
-Base.@deprecate triangulate{F<:Face}(t::Type{F}, f::Face) decompose(t, f)
+import Base.@deprecate
+
+@deprecate triangulate{F<:Face}(t::Type{F}, f::Face) decompose(t, f)
+
+@deprecate call{T}(t::Type{Vector{Point{3,T}}}, r::HyperRectangle{3, T}) decompose(t, r)
+@deprecate call{T}(t::Type{Vector{Point{2,T}}}, r::HyperRectangle{2, T}) decompose(t, r)
+
+
+# TODO
+# These are very tightly coupled to HomogenousMesh.
+getindex{PT}(r::Rectangle, t::Type{Point{2, PT}}) = decompose(t, r)
+getindex{PT}(p::Pyramid, t::Type{Point{3, PT}}) = decompose(t, p)
+getindex{ET}(q::Quad, t::Type{Point{3, ET}}) = decompose(t, q)
+

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,1 @@
+Base.@deprecate triangulate{F<:Face}(t::Type{F}, f::Face) decompose(t, f)

--- a/src/faces.jl
+++ b/src/faces.jl
@@ -12,6 +12,22 @@ Triangulate an N-Face into a tuple of triangular faces.
     v
 end
 
+"""
+Extract all line segments in a Face.
+"""
+@generated function Base.call{N, FT1, FT2, O1, O2}(::Type{Tuple{Face{2, FT1, O1}}},
+                                       f::Face{N, FT2, O2})
+    @assert 2 <= N # other wise degenerate
+
+    v = Expr(:tuple)
+    append!(v.args, [:(Face{2,$FT1,$O1}(f[$(i)]+$(-O2+O1),
+                                        f[$(i+1)]+$(-O2+O1))) for i = 1:N-1])
+    # connect vertices N and 1
+    push!(v.args, :(Face{2,$FT1,$O1}(f[$(N)]+$(-O2+O1),
+                                     f[$(1)]+$(-O2+O1))))
+    v
+end
+
 function getindex{T,N,FD,FT,Offset}(a::Array{T,N}, i::Face{FD, FT, Offset})
     a[[(map(Int,i)-Offset)...]]
 end

--- a/src/faces.jl
+++ b/src/faces.jl
@@ -1,33 +1,3 @@
-"""
-Triangulate an N-Face into a tuple of triangular faces.
-"""
-@generated function triangulate{N, FT1, FT2, O1, O2}(::Type{Face{3, FT1, O1}},
-                                       f::Face{N, FT2, O2})
-    @assert 3 <= N # other wise degenerate
-
-    v = Expr(:tuple)
-    append!(v.args, [:(Face{3,$FT1,$O1}(f[1]+$(-O2+O1),
-                                        f[$(i-1)]+$(-O2+O1),
-                                        f[$(i)]+$(-O2+O1))) for i = 3:N])
-    v
-end
-
-"""
-Extract all line segments in a Face.
-"""
-@generated function Base.call{N, FT1, FT2, O1, O2}(::Type{Tuple{Face{2, FT1, O1}}},
-                                       f::Face{N, FT2, O2})
-    @assert 2 <= N # other wise degenerate
-
-    v = Expr(:tuple)
-    append!(v.args, [:(Face{2,$FT1,$O1}(f[$(i)]+$(-O2+O1),
-                                        f[$(i+1)]+$(-O2+O1))) for i = 1:N-1])
-    # connect vertices N and 1
-    push!(v.args, :(Face{2,$FT1,$O1}(f[$(N)]+$(-O2+O1),
-                                     f[$(1)]+$(-O2+O1))))
-    v
-end
-
 function getindex{T,N,FD,FT,Offset}(a::Array{T,N}, i::Face{FD, FT, Offset})
     a[[(map(Int,i)-Offset)...]]
 end

--- a/test/hyperrectangles.jl
+++ b/test/hyperrectangles.jl
@@ -41,11 +41,11 @@ end
 
 context("fact points function") do
     a = HyperRectangle(Vec(0,0),Vec(1,1))
-    pt_expa = Vector[Point(0,0), Point(0,1), Point(1,0), Point(1,1)]
-    @fact Vector{Point{2,Int}}(a) --> pt_expa
+    pt_expa = (Point(0,0), Point(0,1), Point(1,0), Point(1,1))
+    @fact decompose(Point{2,Int},a) --> pt_expa
     b = HyperRectangle(Vec(0,0,0),Vec(1,1,1))
-    pt_expb = Vector[Point(0,0,0),Point(0,0,1),Point(0,1,0),Point(0,1,1),Point(1,0,0),Point(1,0,1),Point(1,1,0),Point(1,1,1)]
-    @fact Vector{Point{3,Int}}(b) --> pt_expb
+    pt_expb = (Point(0,0,0),Point(0,0,1),Point(0,1,0),Point(0,1,1),Point(1,0,0),Point(1,0,1),Point(1,1,0),Point(1,1,1))
+    @fact decompose(Point{3,Int}, b) --> pt_expb
 end
 
 context("fact empty constructor on 0.4") do

--- a/test/meshtypes.jl
+++ b/test/meshtypes.jl
@@ -23,14 +23,14 @@ context("Merging Mesh") do
     @fact hasfaces(axis) --> true
     @fact hasnormals(axis) --> true
     @fact hascolors(axis) --> false
-    @fact triangulate(GLTriangle, Face{4, Int, 0}(1,2,3,4)) --> (Face{3,UInt32,-1}(0,1,2), Face{3,UInt32,-1}(0,2,3))
-    @fact triangulate(Face{3,Int,-1}, Face{4, Int, -1}(1,2,3,4)) --> (Face{3,Int,-1}(1,2,3),Face{3,Int,-1}(1,3,4))
-    @fact triangulate(Face{3,Int,2}, Face{4, Int, 1}(1,2,3,4)) --> (Face{3,Int,2}(2,3,4),Face{3,Int,2}(2,4,5))
-    @fact Tuple{Face{2,Int,0}}(Face{4, Int, 0}(1,2,3,4)) --> (Face{2,Int,0}(1,2),
-                                                              Face{2,Int,0}(2,3),
-                                                              Face{2,Int,0}(3,4),
-                                                              Face{2,Int,0}(4,1))
-end
+    @fact decompose(GLTriangle, Face{4, Int, 0}(1,2,3,4)) --> (Face{3,UInt32,-1}(0,1,2), Face{3,UInt32,-1}(0,2,3))
+    @fact decompose(Face{3,Int,-1}, Face{4, Int, -1}(1,2,3,4)) --> (Face{3,Int,-1}(1,2,3),Face{3,Int,-1}(1,3,4))
+    @fact decompose(Face{3,Int,2}, Face{4, Int, 1}(1,2,3,4)) --> (Face{3,Int,2}(2,3,4),Face{3,Int,2}(2,4,5))
+    @fact decompose(Face{2,Int,0}, Face{4, Int, 0}(1,2,3,4)) --> (Face{2,Int,0}(1,2),
+                                                                  Face{2,Int,0}(2,3),
+                                                                  Face{2,Int,0}(3,4),
+                                                                  Face{2,Int,0}(4,1))
+    end
 
 context("Show") do
     baselen = 0.4f0

--- a/test/meshtypes.jl
+++ b/test/meshtypes.jl
@@ -26,6 +26,10 @@ context("Merging Mesh") do
     @fact triangulate(GLTriangle, Face{4, Int, 0}(1,2,3,4)) --> (Face{3,UInt32,-1}(0,1,2), Face{3,UInt32,-1}(0,2,3))
     @fact triangulate(Face{3,Int,-1}, Face{4, Int, -1}(1,2,3,4)) --> (Face{3,Int,-1}(1,2,3),Face{3,Int,-1}(1,3,4))
     @fact triangulate(Face{3,Int,2}, Face{4, Int, 1}(1,2,3,4)) --> (Face{3,Int,2}(2,3,4),Face{3,Int,2}(2,4,5))
+    @fact Tuple{Face{2,Int,0}}(Face{4, Int, 0}(1,2,3,4)) --> (Face{2,Int,0}(1,2),
+                                                              Face{2,Int,0}(2,3),
+                                                              Face{2,Int,0}(3,4),
+                                                              Face{2,Int,0}(4,1))
 end
 
 context("Show") do


### PR DESCRIPTION
Implementing Face{3} and Face{2} for #20 to see how the syntax works out. The big issue is that the `NTuple{Face}` is not valid, so `Tuple` must be used instead. I think finding a general word for this would be good.