### PR TITLE
[WIP/RFC] Add Simplicial Complexes

### DIFF
--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -43,6 +43,7 @@ include("display.jl")
 include("slice.jl")
 include("decompose.jl")
 include("deprecated.jl")
+include("orientation.jl")
 
 export AABB,
        AbsoluteRectangle,
@@ -114,6 +115,7 @@ export AABB,
        hastexturecoordinates,
        hasvertices,
        height,
+       isclosed,
        isinside,
        isoutside,
        max_dist_dim,

--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -29,6 +29,7 @@ import Base: ==,
 
 include("types.jl")
 include("simplices.jl")
+include("push.jl")
 include("algorithms.jl")
 include("faces.jl")
 include("hyperrectangles.jl")
@@ -81,6 +82,7 @@ export AABB,
        Particle,
        PlainMesh,
        Point,
+       PureSimplicialComplex,
        Pyramid,
        Quad,
        Rectangle,

--- a/src/display.jl
+++ b/src/display.jl
@@ -7,3 +7,11 @@ function show{M <: HMesh}(io::IO, m::M)
     end
     println(io, ")")
 end
+
+function Base.show(io::IO, p::PureSimplicialComplex)
+    println(typeof(p).name)
+    for i in p.simplices
+        println("$(typeof(i)) (length: $(length(i))):")
+        println(i)
+    end
+end

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -1,0 +1,16 @@
+"""
+Determine if a `PureSimplicialComplex{3}` is closed. This checks that for
+all edges, there is one with the opposite orientation.
+"""
+function isclosed(p::PureSimplicialComplex{3})
+    edges = p.simplices[2]
+    for edge in edges
+        opposite_edge = Simplex(edge[2], edge[1])
+        if opposite_edge in edges
+            continue
+        else
+            return false
+        end
+    end
+    true
+end

--- a/src/push.jl
+++ b/src/push.jl
@@ -1,0 +1,12 @@
+"""
+Add a Simplex to a PureSimplicialComplex.
+"""
+function Base.push!{N1,N2}(p::PureSimplicialComplex{N1}, s::Simplex{N2})
+    @assert N2 <= N1 # otherwise we would have type unstability
+    for i = 1:N1
+        faces = decompose(Simplex{i}, s)
+        for face in faces
+            push!(p.simplices[i], face)
+        end
+    end
+end

--- a/src/push.jl
+++ b/src/push.jl
@@ -3,7 +3,7 @@ Add a Simplex to a PureSimplicialComplex.
 """
 function Base.push!{N1,N2}(p::PureSimplicialComplex{N1}, s::Simplex{N2})
     @assert N2 <= N1 # otherwise we would have type unstability
-    for i = 1:N1
+    for i = 1:N2
         faces = decompose(Simplex{i}, s)
         for face in faces
             push!(p.simplices[i], face)

--- a/src/types.jl
+++ b/src/types.jl
@@ -15,6 +15,15 @@ is not the same as most mathematical texts.
 """
 abstract AbstractSimplex{N,T} <: FixedVector{N,T}
 
+"""
+Abstract to classify Simplicial Complexes. `N` corresponds to the order of
+the Complex, which will be one more than the mathematical terminology
+(i.e. a two-simplicial complex corresponds to `AbstractSimplicialComplex{3}`).
+Note that this also is an abstract, so it is not an 'abstract simplicial
+complex' in the methematica sense. We use more concrete terminology for types
+such as `PureSimplicialComplex`.
+"""
+abstract AbstractSimplicialComplex{N,T} <: FixedVector{N,T}
 
 """
 A `Simplex` is a generalization of an N-dimensional tetrahedra and can be thought
@@ -34,6 +43,15 @@ to allow embedding in higher-order spaces by parameterizing on `T`.
 """
 immutable Simplex{N,T} <: AbstractSimplex{N,T}
     _::NTuple{N,T}
+end
+
+"""
+A `PureSimplicialComplex` is a composition of simplices such that it is
+finite and every facet has the same dimension. This is enforced by the
+type parameter `T`.
+"""
+immutable PureSimplicialComplex{N,T} <: AbstractSimplicialComplex{N,T}
+    simplices::NTuple{N}
 end
 
 immutable Normal{N, T} <: FixedVector{N, T}

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -23,4 +23,12 @@ context("PureSimplicialComplex") do
     @fact length(p.simplices[1]) --> 4
     @fact length(p.simplices[2]) --> 12
     @fact length(p.simplices[3]) --> 4
+    @fact isclosed(p) --> true
+    p2 = PureSimplicialComplex{3,Point{2,Int}}()
+    push!(p2, Simplex(Point(0,0), Point(0,1), Point(1,0)))
+    push!(p2, Simplex(Point(1,0), Point(1,0), Point(1,1)))
+    @fact isclosed(p2) --> false
+    @fact length(p2.simplices[1]) --> 4
+    @fact length(p2.simplices[2]) --> 6
+    @fact length(p2.simplices[3]) --> 2
 end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -11,3 +11,16 @@ context("Simplex") do
     s = Simplex(Point(1,2), Point(2,3))
     @fact s --> Simplex{2,Point{2,Int64}}((Point{2,Int64}((1,2)),Point{2,Int64}((2,3))))
 end
+
+context("PureSimplicialComplex") do
+    p = PureSimplicialComplex{3,Symbol}()
+    # symbolically construct a tetrahedra
+    push!(p, Simplex(:x1, :x2, :x3))
+    push!(p, Simplex(:x3, :x2, :x4))
+    push!(p, Simplex(:x1, :x4, :x2))
+    push!(p, Simplex(:x1, :x3, :x4))
+    @fact length(p.simplices) --> 3
+    @fact length(p.simplices[1]) --> 4
+    @fact length(p.simplices[2]) --> 12
+    @fact length(p.simplices[3]) --> 4
+end


### PR DESCRIPTION
This is a more constrained definition of a mesh. It is useful for exploring properties of Polyhedra. One example is the `isclosed` method, which can be useful for determining if a mesh is missing faces. For example, this would ensure calls to `slice` produce polygons when the slice height is in the domain.

The hope is that by developing a more rigorous type hierarchy we will learn faster, and more generic, ways to compute properties and perform operations. Likewise, I have started exploring using symbols for structure, which should make opportunities for parameterization more apparent. 

One pain point is the design of `PureSimpicialComplex` around a Tuple of sets. It would be great to come up with type that has more deterministic info on the types in the Tuple.
