### PR TITLE
deprecate Rectangle and rename as SimpleRectangle

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,12 +1,14 @@
-import Base.@deprecate
+import Base: @deprecate, @deprecate_binding
 
 @deprecate triangulate{F<:Face}(t::Type{F}, f::Face) decompose(t, f)
 
 @deprecate call{N,T}(t::Type{Vector{Point{N,T}}}, r::HyperRectangle{N, T}) decompose(t, r)
 
+@deprecate_binding Rectangle SimpleRectangle
+
 # TODO
 # These are very tightly coupled to HomogenousMesh.
-getindex{PT}(r::Rectangle, t::Type{Point{2, PT}}) = decompose(t, r)
+getindex{PT}(r::SimpleRectangle, t::Type{Point{2, PT}}) = decompose(t, r)
 getindex{PT}(p::Pyramid, t::Type{Point{3, PT}}) = decompose(t, p)
 getindex{ET}(q::Quad, t::Type{Point{3, ET}}) = decompose(t, q)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -81,12 +81,16 @@ immutable HyperSphere{N, T} <: GeometryPrimitive{N}
     r::T
 end
 
-immutable Rectangle{T} <: GeometryPrimitive{2}
+immutable SimpleRectangle{T} <: GeometryPrimitive{2}
     x::T
     y::T
     w::T
     h::T
 end
+
+# TODO remove before 0.2.0 tag
+const Rectangle = SimpleRectangle
+
 
 immutable Quad{T} <: GeometryPrimitive{3}
     downleft::Vec{3, T}


### PR DESCRIPTION
This is so we can subtype HyperRectangle in forthcoming releases (startign with v0.2.0). Part of the on-going project to unify types.