### PR TITLE
Improve codegen for getindex(::Array, ::Face)

### DIFF
--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -42,6 +42,7 @@ include("display.jl")
 include("slice.jl")
 include("decompose.jl")
 include("deprecated.jl")
+include("checkbounds.jl")
 
 export AABB,
        AbsoluteRectangle,

--- a/src/checkbounds.jl
+++ b/src/checkbounds.jl
@@ -6,7 +6,7 @@ function Base.checkbounds{VT,FT,FD,FO}(m::AbstractMesh{VT,Face{FD,FT,FO}})
     isempty(faces(m)) && return true # nothing to worry about I guess
 
     # index max and min
-    const i = 1 + FO # normalize face offset
+    const i = one(FO) + FO # normalize face offset
     s = length(vertices(m)) + FO
 
     for face in faces(m)

--- a/src/checkbounds.jl
+++ b/src/checkbounds.jl
@@ -1,0 +1,19 @@
+"""
+Check the `Face` indices to ensure they are in the bounds of the vertex
+array of the `AbstractMesh`.
+"""
+function Base.checkbounds{VT,FT,FD,FO}(m::AbstractMesh{VT,Face{FD,FT,FO}})
+    isempty(faces(m)) && return true # nothing to worry about I guess
+
+    # index max and min
+    const i = 1 + FO # normalize face offset
+    s = length(vertices(m)) + FO
+
+    for face in faces(m)
+        # I hope this is unrolled
+        for elt in face
+            i <= elt && elt <= s || return false
+        end
+    end
+    return true
+end

--- a/src/faces.jl
+++ b/src/faces.jl
@@ -1,17 +1,11 @@
 """
 Given an Array, `a`, and a face, `f`, return a tuple of numbers
 interpreting the values and offset of the face as indices into `A`.
-"""
-@generated function getindex{T,N,FD,FT,Offset}(a::Array{T,N},
-                                               f::Face{FD, FT, Offset})
-    v = Expr(:tuple)
-    for i = 1:FD
-        push!(v.args, Expr(:ref, :a, :(f[$i]-Offset)))
-    end
-    Expr(:(::), v, :(NTuple{FD,T}))
-end
 
-@generated function Base.unsafe_getindex{T,N,FD,FT,Offset}(a::Array{T,N},
+Note: This is not bounds checked. It is recommended that you use
+`checkbounds` to confirm the indices are safe for loops.
+"""
+@generated function Base.getindex{T,N,FD,FT,Offset}(a::Array{T,N},
                                                f::Face{FD, FT, Offset})
     v = Expr(:tuple)
     for i = 1:FD

--- a/src/faces.jl
+++ b/src/faces.jl
@@ -4,6 +4,8 @@ interpreting the values and offset of the face as indices into `A`.
 
 Note: This is not bounds checked. It is recommended that you use
 `checkbounds` to confirm the indices are safe for loops.
+Also be aware when writing generic code that faces may be of more than
+3 vertices.
 """
 @generated function Base.getindex{T,N,FD,FT,Offset}(a::Array{T,N},
                                                f::Face{FD, FT, Offset})

--- a/src/faces.jl
+++ b/src/faces.jl
@@ -1,6 +1,25 @@
-function getindex{T,N,FD,FT,Offset}(a::Array{T,N}, i::Face{FD, FT, Offset})
-    a[[(map(Int,i)-Offset)...]]
+"""
+Given an Array, `a`, and a face, `f`, return a tuple of numbers
+interpreting the values and offset of the face as indices into `A`.
+"""
+@generated function getindex{T,N,FD,FT,Offset}(a::Array{T,N},
+                                               f::Face{FD, FT, Offset})
+    v = Expr(:tuple)
+    for i = 1:FD
+        push!(v.args, Expr(:ref, :a, :(f[$i]-Offset)))
+    end
+    Expr(:(::), v, :(NTuple{FD,T}))
 end
+
+@generated function Base.unsafe_getindex{T,N,FD,FT,Offset}(a::Array{T,N},
+                                               f::Face{FD, FT, Offset})
+    v = Expr(:tuple)
+    for i = 1:FD
+        push!(v.args, Expr(:call, Base.unsafe_getindex, :a, :(f[$i]-Offset)))
+    end
+    Expr(:(::), v, :(NTuple{FD,T}))
+end
+
 function setindex!{T,N,FD,FT,Offset}(a::Array{T,N}, b::Array{T,N}, i::Face{FD, FT, Offset})
     a[[(map(Int,i)-Offset)...]] = b
 end

--- a/test/faces.jl
+++ b/test/faces.jl
@@ -1,0 +1,6 @@
+context("faces") do
+    a = [1,2,3,4]
+    @fact a[Face{3,Int,0}(1,2,3)] --> (1,2,3)
+    @fact a[Face{3,Int,-1}(0,1,2)] --> (1,2,3)
+    @fact a[Face{3,Int,1}(2,3,4)] --> (1,2,3)
+end

--- a/test/meshtypes.jl
+++ b/test/meshtypes.jl
@@ -85,4 +85,23 @@ context("Slice") do
     @fact length(s2) --> length(exp2)
 end
 
+context("checkbounds") do
+    m1 = HomogenousMesh([Point{3,Float64}(0.0,0.0,10.0),
+                         Point{3,Float64}(0.0,10.0,10.0),
+                         Point{3,Float64}(0.0,0.0,0.0)],
+                        [Face{3,Int,0}(1,2,3)])
+    @fact checkbounds(m1) --> true
+    m2 = HomogenousMesh([Point{3,Float64}(0.0,0.0,10.0),
+                         Point{3,Float64}(0.0,10.0,10.0),
+                         Point{3,Float64}(0.0,0.0,0.0)],
+                        [Face{3,Int,-1}(1,2,3)])
+    @fact checkbounds(m2) --> false
+    # empty case
+    m3 = HomogenousMesh([Point{3,Float64}(0.0,0.0,10.0),
+                         Point{3,Float64}(0.0,10.0,10.0),
+                         Point{3,Float64}(0.0,0.0,0.0)],
+                        Face{3,Int,-1}[])
+    @fact checkbounds(m3) --> true
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ typealias Vec3f0 Vec{3, Float32}
 
 facts("GeometryTypes") do
     include("hyperrectangles.jl")
+    include("faces.jl")
     include("meshtypes.jl")
     include("distancefields.jl")
     include("primitives.jl")


### PR DESCRIPTION
#28 brought this method to my attention so I made some tweaks for codegen.
Apologies for my aversion to regular macro style. I really can't figure out hygiene and have gotten perhaps too good at avoiding it.

Open questions:
- Should we make unsafe_getindex the default?

I have tested some packages depending on this and they don't seem to care that the return type changed to tuple. (we will need to tag v0.2.0 after this though). 

CC: @SimonDanisch @dreammaker 

**Before**
```
julia> @code_native getindex([1,2,3,4],f)
	.text
Filename: /home/steve/.julia/v0.4/GeometryTypes/src/faces.jl
Source line: 2
	pushq	%rbp
	movq	%rsp, %rbp
Source line: 2
	pushq	%r15
	pushq	%r14
	pushq	%r12
	pushq	%rbx
	subq	$48, %rsp
	movq	$8, -80(%rbp)
	movabsq	$jl_pgcstack, %r14
	movq	(%r14), %rax
	movq	%rax, -72(%rbp)
	leaq	-80(%rbp), %rax
	movq	%rax, (%r14)
	vxorps	%xmm0, %xmm0, %xmm0
	vmovups	%xmm0, -48(%rbp)
	vmovups	%xmm0, -64(%rbp)
Source line: 2
	movq	(%rsi), %r15
	movq	8(%rsi), %r12
	movq	16(%rsi), %rbx
	movq	%rdi, -64(%rbp)
	movabsq	$jl_gc_allocobj, %rax
	movabsq	$139678908196536, %rcx  # imm = 0x7F0987B4A6B8
	movabsq	$139678905658840, %rdx  # imm = 0x7F09878DEDD8
	movq	(%rdx), %rdx
	movq	%rdx, -56(%rbp)
	movq	(%rcx), %rcx
	movq	%rcx, -48(%rbp)
	movl	$24, %edi
	callq	*%rax
	movabsq	$139678934228976, %rdx  # imm = 0x7F098941DFF0
Source line: 2
	leaq	-56(%rbp), %rsi
Source line: 2
	movabsq	$jl_f_apply, %rcx
	movq	%rdx, -8(%rax)
	movq	%rbx, 16(%rax)
	movq	%r12, 8(%rax)
	movq	%r15, (%rax)
	movq	%rax, -40(%rbp)
	xorl	%edi, %edi
	movl	$3, %edx
	callq	*%rcx
Source line: 2
	leaq	-64(%rbp), %rsi
Source line: 2
	movabsq	$jl_apply_generic, %rcx
	movq	%rax, -56(%rbp)
	movabsq	$139678900639408, %rdi  # imm = 0x7F09874156B0
	movl	$2, %edx
	callq	*%rcx
	movq	-72(%rbp), %rcx
	movq	%rcx, (%r14)
	addq	$48, %rsp
	popq	%rbx
	popq	%r12
	popq	%r14
	popq	%r15
	popq	%rbp
	ret
```

**Bounds checking**
```
julia> @code_native getindex([1,2,3,4],f)
	.text
Filename: /home/steve/.julia/v0.4/GeometryTypes/src/faces.jl
Source line: 7
	pushq	%rbp
	movq	%rsp, %rbp
	movq	%rsi, %r9
Source line: 7
	movq	8(%r9), %rsi
	movq	(%rdx), %r8
	leaq	-1(%r8), %rcx
	cmpq	%rsi, %rcx
	jae	L98
	movq	8(%rdx), %rcx
	leaq	-1(%rcx), %rax
	cmpq	%rsi, %rax
	jae	L117
	movq	16(%rdx), %rdx
	leaq	-1(%rdx), %rax
	cmpq	%rsi, %rax
	jae	L136
	movq	(%r9), %rsi
	movq	-8(%rsi,%r8,8), %rax
	movq	-8(%rsi,%rcx,8), %rcx
	movq	-8(%rsi,%rdx,8), %rdx
	movq	%rdx, 16(%rdi)
	movq	%rcx, 8(%rdi)
	movq	%rax, (%rdi)
	movq	%rdi, %rax
	movq	%rbp, %rsp
	popq	%rbp
	ret
L98:	movq	%rsp, %rcx
	leaq	-16(%rcx), %rsi
	movq	%rsi, %rsp
	movq	%r8, -16(%rcx)
	jmpq	L150
L117:	movq	%rsp, %rdx
	leaq	-16(%rdx), %rsi
	movq	%rsi, %rsp
	movq	%rcx, -16(%rdx)
	jmpq	L150
L136:	movq	%rsp, %rcx
	leaq	-16(%rcx), %rsi
	movq	%rsi, %rsp
	movq	%rdx, -16(%rcx)
L150:	movabsq	$jl_bounds_error_ints, %rcx
	movq	%r9, %rdi
	movl	$1, %edx
	callq	*%rcx
```
**Inbounds**
```
julia> @code_native Base.unsafe_getindex([1,2,3,4],f)
	.text
Filename: /home/steve/.julia/v0.4/GeometryTypes/src/faces.jl
Source line: 16
	pushq	%rbp
	movq	%rsp, %rbp
Source line: 16
	movq	(%rdx), %rax
	movq	8(%rdx), %r8
	movq	(%rsi), %rcx
	movq	-8(%rcx,%rax,8), %rax
	movq	-8(%rcx,%r8,8), %rsi
	movq	16(%rdx), %rdx
	movq	-8(%rcx,%rdx,8), %rcx
	movq	%rcx, 16(%rdi)
	movq	%rsi, 8(%rdi)
	movq	%rax, (%rdi)
	movq	%rdi, %rax
	popq	%rbp
	ret
```


