### PR TITLE
fixed rects

### DIFF
--- a/src/convexhulls.jl
+++ b/src/convexhulls.jl
@@ -18,7 +18,7 @@ Base.copy{FG <: AFG}(fl::FG) = FG(copy(vertices(fl)))
 push(fl::AFG, pt) = push!(copy(fl), pt)
 
 vertices(s::Simplex) = s._
-standard_cube_vertices(::Type{Val{1}}) = [Vec(-1), Vec(1)]
+standard_cube_vertices(::Type{Val{1}}) = [Vec(0), Vec(1)]
 _vcat(v1,v2) = Vec(Tuple(v1)..., Tuple(v2)...)
 function _combine_vcat(arr1, arr2)
     T = typeof(_vcat(first(arr1), first(arr2)))
@@ -39,10 +39,10 @@ end
 end
 
 @generated function vertices{N,T}(r::HyperRectangle{N,T})
-    ret_type = NTuple{(2^N), Vec{N,float(T)}}
+    ret_type = NTuple{(2^N), Vec{N,T}}
     quote
         o = origin(r)
-        v = 0.5*widths(r)
+        v = widths(r)
         f(sv) = o + sv .* v
         tuple(map(f, standard_cube_vertices(Val{N}))...)::$ret_type
     end

--- a/src/gjk.jl
+++ b/src/gjk.jl
@@ -64,9 +64,9 @@ any_inside(v::Vec) = v
 support_vector_max(ch::AbstractConvexHull, v) = argmax(x-> x⋅v, vertices(ch))
 support_vector_max(w::Vec, v) = w, w⋅v
 function support_vector_max(c::HyperRectangle, v)
-    s = 0.5widths(c)
-    signs = map(sign, s .* v)::typeof(v)
-    best_pt = origin(c) + signs.*s
+    s = widths(c)
+    takes = map(x -> x > zero(eltype(v)), s .* v)
+    best_pt::typeof(v) = origin(c) + takes.*s
     score = (best_pt ⋅ v)
     return best_pt, score
 end

--- a/test/convexhulls.jl
+++ b/test/convexhulls.jl
@@ -44,7 +44,7 @@ context("Convex Hulls") do
     context("Rects") do
         c = HyperCube(Vec(1.,2), 1.)
         r = HyperRectangle(Vec(1.,2), Vec(1.,1))
-        fh = FlexibleConvexHull([ Vec(0.5,1.5), Vec(0.5,2.5), Vec(1.5,1.5), Vec(1.5,2.5)])
+        fh = FlexibleConvexHull([ Vec(1,2.), Vec(1.,3.), Vec(2.,2.), Vec(2.,3.)])
         objects = (c,r,fh)
 
         @fact (@inferred convert(HyperRectangle, c)) --> r

--- a/test/gjk.jl
+++ b/test/gjk.jl
@@ -46,7 +46,7 @@ context("gjk") do
         end
 
         context("Cube") do
-            c = HyperCube(Vec(1.,1,1), 1.)
+            c = HyperCube(Vec(0.5,0.5,0.5), 1.)
             @fact min_euclidean(Vec(2,2,2.), c) ≈ gjk(Vec(2,2,2.), c) ≈ √(3/4) --> true
 
             s = Simplex(Vec(1, 0.5, 0.5), Vec(1,2,3.))
@@ -60,11 +60,11 @@ context("gjk") do
     end
 
     context("support_vector_max") do
-        r = HyperRectangle(Vec(0,0.), Vec(1., 2.))
-        @fact support_vector_max(r, Vec(1,0.)) --> (Vec(0.5,0.), 0.5)
-        @fact support_vector_max(r, Vec(2,0.)) --> (Vec(0.5,0.), 1.)
-        @fact support_vector_max(r, Vec(-1,0.)) --> (Vec(-0.5,0.), 0.5)
-        @fact support_vector_max(r, Vec(0, 1.)) --> (Vec(0.,1.), 1.)
+        r = HyperRectangle(Vec(-0.5, -1.), Vec(1., 2.))
+        @fact support_vector_max(r, Vec(1,0.)) --> (Vec(0.5,-1.), 0.5)
+        @fact support_vector_max(r, Vec(2,0.)) --> (Vec(0.5,-1.), 1.)
+        @fact support_vector_max(r, Vec(-1,0.)) --> (Vec(-0.5,-1.), 0.5)
+        @fact support_vector_max(r, Vec(0, 1.)) --> (Vec(-0.5,1.), 1.)
         @fact support_vector_max(r, Vec(1, 1.)) --> (Vec(0.5,1.), 1.5)
         @fact support_vector_max(FlexibleConvexHull(r), Vec(1, 1.)) --> (Vec(0.5,1.), 1.5)
 


### PR DESCRIPTION
Fixed issues from wrong calculation of vertices of HyperCubes, HyperRectangles like:

Wrong:
```
using Geometry Types

HyperCube(Vec(0,0), 1) |> vertices
(Vec(-0.5,-0.5),Vec(-0.5,0.5),Vec(0.5,-0.5),Vec(0.5,0.5))
```

Correct:
```
using Geometry Types

HyperCube(Vec(0,0), 1) |> vertices
(Vec(0,0),Vec(0,1),Vec(1,0),Vec(1,1))
```

