### PR TITLE
[wip] drop 0.4 + fixes for 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
-julia 0.4
+julia 0.5
 FixedSizeArrays
 ColorTypes
-Compat 0.7.15
+Compat 0.18
 Iterators
+FixedPointNumbers

--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -4,13 +4,13 @@ module GeometryTypes
 using FixedSizeArrays
 using ColorTypes
 import Iterators
+import FixedPointNumbers # U8
 
 import FixedSizeArrays: eltype_or, ndims_or
 using Compat
 
 import Base: ==,
              *,
-             call,
              contains,
              convert,
              diff,
@@ -168,6 +168,7 @@ export AABB,
        row,
        radius,
        setindex,
+       slice,
        spacedim,
        starts,
        texturecoordinates,

--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -31,6 +31,10 @@ import Base: ==,
              union,
              unique
 
+if VERSION < v"0.6dev"
+    import Base: slice
+end
+
 
 include("types.jl")
 include("typeutils.jl")

--- a/src/faces.jl
+++ b/src/faces.jl
@@ -26,18 +26,18 @@ convert{T1<:Face}(::Type{T1}, f::T1) = f
 convert{T1<:Face, T2<:Face}(::Type{T1}, f::T2) = T1(f)
 
 # Silly duplication, but call(::FixedVector, ::Any) = convert is overloaded in FixedSizeArrays
-@compat (::Type{F}){F<:Face}(f::F) = f
+(::Type{F}){F<:Face}(f::F) = f
 
-@compat function (::Type{Face{N, T, O}}){T, T2, O, N}(f::Face{N, T2, O})
+function (::Type{Face{N, T, O}}){T, T2, O, N}(f::Face{N, T2, O})
     Face{N, T, O}(convert(NTuple{N, T}, getfield(f, 1)))
 end
 immutable IndexConvertFunc{T1, T2}
 	f::T2
 end
-@compat function (ifunc::IndexConvertFunc{Face{N,T1,O1}, Face{N,T2,O2}}){N,T1,T2,O1,O2}(i)
+function (ifunc::IndexConvertFunc{Face{N,T1,O1}, Face{N,T2,O2}}){N,T1,T2,O1,O2}(i)
 	Int(ifunc.f[i])+Int(O1)-Int(O2)
 end
-@compat function (T::Type{Face{N, T1, O1}}){N, T1, O1, F<:Face}(f::F)
+function (T::Type{Face{N, T1, O1}}){N, T1, O1, F<:Face}(f::F)
 	map(IndexConvertFunc{T,F}(f), T)
 end
 

--- a/src/hyperrectangles.jl
+++ b/src/hyperrectangles.jl
@@ -20,12 +20,12 @@ function _split{H<:HyperRectangle}(b::H, axis, value)
 end
 
 # empty constructor such that update will always include the first point
-@compat function (HR::Type{HyperRectangle{N,T}}){T,N}()
+function (HR::Type{HyperRectangle{N,T}}){T,N}()
     HR(Vec{N,T}(typemax(T)), Vec{N,T}(typemin(T)))
 end
 
 # conversion from other HyperRectangles
-@compat function (HR::Type{HyperRectangle{N,T1}}){N,T1,T2}(a::HyperRectangle{N,T2})
+function (HR::Type{HyperRectangle{N,T1}}){N,T1,T2}(a::HyperRectangle{N,T2})
     HR(Vec{N, T1}(minimum(a)), Vec{N, T1}(widths(a)))
 end
 
@@ -35,7 +35,7 @@ function HyperRectangle{N,T1,T2}(v1::Vec{N,T1}, v2::Vec{N,T2})
 end
 
 
-@compat function (HR::Type{HyperRectangle{N,T}}){N,T}(a::GeometryPrimitive)
+function (HR::Type{HyperRectangle{N,T}}){N,T}(a::GeometryPrimitive)
     HR(Vec{N, T}(minimum(a)), Vec{N, T}(widths(a)))
 end
 """
@@ -63,7 +63,7 @@ function HyperRectangle{T}(r::SimpleRectangle{T})
     HyperRectangle{2,T}(r)
 end
 
-@compat function (::Type{HyperRectangle{N,T}}){N,T}(r::SimpleRectangle)
+function (::Type{HyperRectangle{N,T}}){N,T}(r::SimpleRectangle)
     if N > 2
         return HyperRectangle(Vec{N, T}(T(r.x), T(r.y), Vec{N-2,T}(zero(T))...),
                               Vec{N, T}(T(r.w), T(r.h), Vec{N-2,T}(zero(T))...))
@@ -162,7 +162,7 @@ end
 """
 Construct a HyperRectangle enclosing all points.
 """
-@compat function (t::Type{HyperRectangle{N1, T1}}){N1, T1, PT<:Point}(
+function (t::Type{HyperRectangle{N1, T1}}){N1, T1, PT<:Point}(
         geometry::AbstractArray{PT}
     )
     N2, T2 = length(PT), eltype(PT)
@@ -195,7 +195,7 @@ maximum{T}(a::SimpleRectangle{T}) = Point{2, T}(a.x + widths(a)[1], a.y +widths(
 minimum{T}(a::SimpleRectangle{T}) = Point{2, T}(a.x, a.y)
 origin{T}(a::SimpleRectangle{T}) = Point{2, T}(a.x, a.y)
 
-@compat (::Type{SimpleRectangle}){T}(val::Vec{2, T}) = SimpleRectangle{T}(0, 0, val...)
+(::Type{SimpleRectangle}){T}(val::Vec{2, T}) = SimpleRectangle{T}(0, 0, val...)
 function SimpleRectangle{T}(position::Vec{2,T}, width::Vec{2,T})
     SimpleRectangle{T}(position..., width...)
 end

--- a/src/hypersphere.jl
+++ b/src/hypersphere.jl
@@ -1,6 +1,6 @@
-@compat (::Type{Sphere})(x...) = HyperSphere(x...)
+(::Type{Sphere})(x...) = HyperSphere(x...)
 
-@compat (::Type{Circle})(x...) = HyperSphere(x...)
+(::Type{Circle})(x...) = HyperSphere(x...)
 
 widths{N, T}(c::HyperSphere{N, T}) = Vec{N, T}(radius(c)*2)
 radius(c::HyperSphere) = c.r

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -48,7 +48,7 @@ end
 
 # Needed to not get into an stack overflow
 convert{M <: AbstractMesh}(::Type{M}, mesh::AbstractGeometry) = M(mesh)
-@compat (::Type{HM1}){HM1 <: AbstractMesh}(mesh::HM1) = mesh
+(::Type{HM1}){HM1 <: AbstractMesh}(mesh::HM1) = mesh
 
 """
 Uses decompose to get all the converted attributes from the meshtype and
@@ -57,7 +57,7 @@ Getindex can be defined for any arbitrary geometric type or exotic mesh type.
 This way, we can make sure, that you can convert most of the meshes from one type to the other
 with minimal code.
 """
-@compat function (::Type{HM1}){HM1 <: AbstractMesh}(primitive::Union{AbstractMesh, GeometryPrimitive})
+function (::Type{HM1}){HM1 <: AbstractMesh}(primitive::Union{AbstractMesh, GeometryPrimitive})
     result = Dict{Symbol, Any}()
     for (field, target_type) in zip(fieldnames(HM1), HM1.parameters)
         if target_type != Void
@@ -77,7 +77,7 @@ end
 isvoid{T}(::Type{T}) = false
 isvoid(::Type{Void}) = true
 isvoid{T}(::Type{Vector{T}}) = isvoid(T)
-@compat function (::Type{HM1}){HM1 <: HomogenousMesh}(primitive::HomogenousMesh)
+function (::Type{HM1}){HM1 <: HomogenousMesh}(primitive::HomogenousMesh)
     fnames = fieldnames(HM1)
     args = ntuple(nfields(HM1)) do i
         field, target_type = fnames[i], fieldtype(HM1, i)
@@ -98,7 +98,7 @@ end
 #Should be:
 #function call{M <: HMesh, VT <: Point, FT <: Face}(::Type{M}, vertices::Vector{VT}, faces::Vector{FT})
 # Haven't gotten around to implement the types correctly with abstract types in FixedSizeArrays
-@compat function (::Type{M}){M <: HMesh, VT, FT <: Face}(
+function (::Type{M}){M <: HMesh, VT, FT <: Face}(
         vertices::Vector{Point{3, VT}}, faces::Vector{FT}
     )
     msh = PlainMesh{VT, FT}(vertices=vertices, faces=faces)
@@ -122,12 +122,12 @@ end
 """
 Creates a mesh from keyword arguments, which have to match the field types of the given concrete mesh
 """
-@compat (::Type{M}){M <: HMesh}(; kw_args...) = M(Dict{Symbol, Any}(kw_args))
+(::Type{M}){M <: HMesh}(; kw_args...) = M(Dict{Symbol, Any}(kw_args))
 
 """
 Creates a new mesh from a dict of `fieldname => value` and converts the types to the given meshtype
 """
-@compat function (::Type{M}){M <: HMesh}(attribs::Dict{Symbol, Any})
+function (::Type{M}){M <: HMesh}(attribs::Dict{Symbol, Any})
     newfields = map(zip(fieldnames(HomogenousMesh), M.parameters)) do field_target_type
         field, target_type = field_target_type
         default = fieldtype(HomogenousMesh, field) <: Vector ? Void[] : nothing
@@ -139,7 +139,7 @@ end
 """
 Creates a new mesh from an old one, with changed attributes given by the keyword arguments
 """
-@compat function (::Type{M}){M <: HMesh}(mesh::AbstractMesh, attributes::Dict{Symbol, Any})
+function (::Type{M}){M <: HMesh}(mesh::AbstractMesh, attributes::Dict{Symbol, Any})
     newfields = map(fieldnames(HomogenousMesh)) do field
         get(attributes, field, getfield(mesh, field))
     end
@@ -148,7 +148,7 @@ end
 """
 Creates a new mesh from an old one, with a new constant attribute (like a color)
 """
-@compat function (::Type{HM}){HM <: HMesh, ConstAttrib}(mesh::AbstractMesh, constattrib::ConstAttrib)
+function (::Type{HM}){HM <: HMesh, ConstAttrib}(mesh::AbstractMesh, constattrib::ConstAttrib)
     result = Dict{Symbol, Any}()
     for (field, target_type) in zip(fieldnames(HM), HM.parameters)
         if target_type <: ConstAttrib
@@ -168,7 +168,7 @@ end
 """
 Creates a new mesh from a tuple of a geometry type and a constant attribute
 """
-@compat function (::Type{HM}){HM <: HMesh, ConstAttrib, P<:AbstractGeometry}(x::Tuple{P, ConstAttrib})
+function (::Type{HM}){HM <: HMesh, ConstAttrib, P<:AbstractGeometry}(x::Tuple{P, ConstAttrib})
     any, const_attribute = x
     add_attribute(HM(any), const_attribute)
 end
@@ -235,7 +235,7 @@ end
 immutable MeshMulFunctor{T}
     matrix::Mat{4,4,T}
 end
-@compat (m::MeshMulFunctor{T}){T}(vert) = Vec{3, T}(m.matrix*Vec{4, T}(vert..., 1))
+(m::MeshMulFunctor{T}){T}(vert) = Vec{3, T}(m.matrix*Vec{4, T}(vert..., 1))
 function *{T}(m::Mat{4,4,T}, mesh::AbstractMesh)
     msh = deepcopy(mesh)
     map!(MeshMulFunctor(m), msh.vertices)

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -137,7 +137,7 @@ function topoint{T}(::Type{Point{2, T}}, p::Point{3, T})
     Point{2, T}(p[1], p[2])
 end
 
-@compat function (::Type{M}){M <: AbstractMesh, P <: Point}(
+function (::Type{M}){M <: AbstractMesh, P <: Point}(
         points::AbstractArray{P}
     )
     faces = polygon2faces(points, facetype(M))

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -1,5 +1,5 @@
 
-@compat function (meshtype::Type{T}){T <: AbstractMesh}(c::Pyramid)
+function (meshtype::Type{T}){T <: AbstractMesh}(c::Pyramid)
     T(decompose(vertextype(T), c), decompose(facetype(T), c))
 end
 
@@ -10,7 +10,7 @@ Just walk through all attributes of the mesh and try to decompose it.
 If there are attributes missing, just hope it will get managed by the mesh constructor.
 (E.g. normal calculation, which needs to have vertices and faces present)
 """
-@compat function (meshtype::Type{T}){T <: AbstractMesh}(c::GeometryPrimitive, args...)
+function (meshtype::Type{T}){T <: AbstractMesh}(c::GeometryPrimitive, args...)
     attribs = attributes(T)
     newattribs = Dict{Symbol, Any}()
     for (fieldname, typ) in attribs
@@ -22,9 +22,9 @@ If there are attributes missing, just hope it will get managed by the mesh const
 end
 
 
-@compat function (meshtype::Type{T}){T <: HMesh,HT}(
+function (meshtype::Type{T}){T <: HMesh,HT}(
         c::Union{HyperCube{3,T}, HyperRectangle{3,HT}}
-    
+
 )    xdir = Vec{3, HT}(widths(c)[1],0f0,0f0)
     ydir = Vec{3, HT}(0f0,widths(c)[2],0f0)
     zdir = Vec{3, HT}(0f0,0f0,widths(c)[3])

--- a/src/simplices.jl
+++ b/src/simplices.jl
@@ -2,14 +2,14 @@
 # We need this constructor to route around the FixedSizeArray `call` and
 # so Simplex(Pt, Pt...) etc works. Hopefully these ambiguities will be fixed in
 # forthcoming Julia versions.
-@compat (::Type{S}){S <: Simplex}(s::S) = s
-@compat function (::Type{T}){T<:Simplex,F<:FixedVector}(f::F...)
+(::Type{S}){S <: Simplex}(s::S) = s
+function (::Type{T}){T<:Simplex,F<:FixedVector}(f::F...)
     Simplex{length(f),F}(f)
 end
-@compat (::Type{S}){S <: Simplex}(fs::FlexibleSimplex) = convert(S, fs)
+(::Type{S}){S <: Simplex}(fs::FlexibleSimplex) = convert(S, fs)
 
 # FSA doesn't handle symbols for length 1 well.
-@compat function (::Type{T}){T<:Simplex}(f::Symbol)
+function (::Type{T}){T<:Simplex}(f::Symbol)
     Simplex{1,Symbol}((f,))
 end
 

--- a/src/slice.jl
+++ b/src/slice.jl
@@ -3,7 +3,7 @@ Slice an AbstractMesh at the specified Z axis value.
 Returns a Vector of LineSegments generated from the faces at the specified
 heights. Note: This will not slice in-plane faces.
 """
-function Base.slice{VT<:AbstractFloat,FT<:Integer,O}(mesh::AbstractMesh{Point{3,VT},Face{3,FT,O}}, height::Number)
+function slice{VT<:AbstractFloat,FT<:Integer,O}(mesh::AbstractMesh{Point{3,VT},Face{3,FT,O}}, height::Number)
 
     height_ct = length(height)
     # intialize the LineSegment array

--- a/src/typealias.jl
+++ b/src/typealias.jl
@@ -1,11 +1,11 @@
-#Create typealiases like Mat4f0, Point2, Point2f0
+#Create constes like Mat4f0, Point2, Point2f0
 for i=1:4
     for T=[:Point, :Vec]
         name 	= Symbol("$T$i")
         namef0 	= Symbol("$T$(i)f0")
         @eval begin
-            typealias $name $T{$i}
-            typealias $namef0 $T{$i, Float32}
+            @compat const $name = $T{$i}
+            @compat const $namef0 = $T{$i, Float32}
             export $name
             export $namef0
         end
@@ -13,84 +13,85 @@ for i=1:4
     name   = Symbol("Mat$i")
     namef0 = Symbol("Mat$(i)f0")
     @eval begin
-        typealias $name $Mat{$i,$i}
-        typealias $namef0 $Mat{$i,$i, Float32}
+        @compat const $name = $Mat{$i,$i}
+        @compat const $namef0 = $Mat{$i,$i, Float32}
         export $name
         export $namef0
     end
 end
 
 #Type aliases
+@compat const U8 = FixedPointNumbers.Normed{UInt8, 8}
 
 """
 An alias for a one-simplex, corresponding to LineSegment{T} -> Simplex{2,T}.
 """
-typealias LineSegment{T} Simplex{2,T}
+@compat const LineSegment{T} = Simplex{2,T}
 
-typealias Triangle{T} Face{3, T, 0}
-typealias GLFace{Dim} Face{Dim, Cuint, -1} #offset is relative to julia, so -1 is 0-indexed
-typealias GLTriangle  Face{3, Cuint, -1}
-typealias GLQuad      Face{4, Cuint, -1}
+@compat const Triangle{T} = Face{3, T, 0}
+@compat const GLFace{Dim} = Face{Dim, Cuint, -1} #offset is relative to julia, so -1 is 0-indexed
+@compat const GLTriangle  = Face{3, Cuint, -1}
+@compat const GLQuad      = Face{4, Cuint, -1}
 
-typealias Cube{T}   HyperCube{3, T}
+@compat const Cube{T} = HyperCube{3, T}
 
 """
 An alias for a HyperSphere of dimension 2. i.e. Circle{T} -> HyperSphere{2, T}
 """
-typealias Circle{T} HyperSphere{2, T}
+@compat const Circle{T} = HyperSphere{2, T}
 
 """
 An alias for a HyperSphere of dimension 3. i.e. Sphere{T} -> HyperSphere{3, T}
 """
-typealias Sphere{T} HyperSphere{3, T}
+@compat const Sphere{T} = HyperSphere{3, T}
 
-typealias AbsoluteRectangle{T} HyperRectangle{2, T}
+@compat const AbsoluteRectangle{T} = HyperRectangle{2, T}
 
 """
 AABB, or Axis Aligned Bounding Box, is an alias for a 3D HyperRectangle.
 """
-typealias AABB{T} HyperRectangle{3, T}
-@compat (::Type{AABB})(m...) = HyperRectangle(m...)
+@compat const AABB{T} = HyperRectangle{3, T}
+(::Type{AABB})(m...) = HyperRectangle(m...)
 
-typealias HMesh HomogenousMesh
+@compat const HMesh = HomogenousMesh
 
-typealias UV{T} TextureCoordinate{2, T}
-typealias UVW{T} TextureCoordinate{3, T}
+@compat const UV{T} = TextureCoordinate{2, T}
+@compat const UVW{T} = TextureCoordinate{3, T}
 
 """
 A `SimpleMesh` is an alias for a `HomogenousMesh` parameterized only by
 vertex and face types.
 """
-typealias SimpleMesh{VT, FT} HMesh{VT, FT, Void, Void, Void, Void, Void}
-typealias PlainMesh{VT, FT} HMesh{Point{3, VT}, FT, Void, Void, Void, Void, Void}
-typealias GLPlainMesh PlainMesh{Float32, GLTriangle}
+@compat const SimpleMesh{VT, FT} = HMesh{VT, FT, Void, Void, Void, Void, Void}
+@compat const PlainMesh{VT, FT} = HMesh{Point{3, VT}, FT, Void, Void, Void, Void, Void}
+@compat const GLPlainMesh = PlainMesh{Float32, GLTriangle}
 
-typealias Mesh2D{VT, FT} HMesh{Point{2, VT}, FT, Void, Void, Void, Void, Void}
-typealias GLMesh2D Mesh2D{Float32, GLTriangle}
+@compat const Mesh2D{VT, FT} = HMesh{Point{2, VT}, FT, Void, Void, Void, Void, Void}
+@compat const GLMesh2D = Mesh2D{Float32, GLTriangle}
 
-typealias UVMesh{VT, FT, UVT} HMesh{Point{3, VT}, FT, Void, UV{UVT}, Void, Void, Void}
-typealias GLUVMesh UVMesh{Float32, GLTriangle, Float32}
+@compat const UVMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Void, UV{UVT}, Void, Void, Void}
+@compat const GLUVMesh = UVMesh{Float32, GLTriangle, Float32}
 
-typealias UVWMesh{VT, FT, UVT} HMesh{Point{3, VT}, FT, Void, UVW{UVT}, Void, Void, Void}
-typealias GLUVWMesh UVWMesh{Float32, GLTriangle, Float32}
+@compat const UVWMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Void, UVW{UVT}, Void, Void, Void}
+@compat const GLUVWMesh = UVWMesh{Float32, GLTriangle, Float32}
 
-typealias NormalMesh{VT, FT, NT} HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, Void, Void}
-typealias GLNormalMesh NormalMesh{Float32, GLTriangle, Float32}
+@compat const NormalMesh{VT, FT, NT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, Void, Void}
+@compat const GLNormalMesh = NormalMesh{Float32, GLTriangle, Float32}
 
-typealias UVMesh2D{VT, FT, UVT} HMesh{Point{2, VT}, FT, Void, UV{UVT}, Void, Void, Void}
-typealias GLUVMesh2D UVMesh2D{Float32, GLTriangle, Float32}
+@compat const UVMesh2D{VT, FT, UVT} = HMesh{Point{2, VT}, FT, Void, UV{UVT}, Void, Void, Void}
+@compat const GLUVMesh2D = UVMesh2D{Float32, GLTriangle, Float32}
 
-typealias NormalColorMesh{VT, FT, NT, CT} HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, CT, Void, Void}
-typealias GLNormalColorMesh NormalColorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
+@compat const NormalColorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, CT, Void, Void}
+@compat const GLNormalColorMesh = NormalColorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
 
-typealias NormalVertexcolorMesh{VT, FT, NT, CT} HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Vector{CT}, Void, Void}
-typealias GLNormalVertexcolorMesh NormalVertexcolorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
+@compat const NormalVertexcolorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Vector{CT}, Void, Void}
+@compat const GLNormalVertexcolorMesh = NormalVertexcolorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
 
-typealias NormalAttributeMesh{VT, FT, NT, AT, A_ID_T} HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, AT, A_ID_T}
-typealias GLNormalAttributeMesh NormalAttributeMesh{Float32, GLTriangle, Float32, Vector{RGBA{U8}}, Float32}
+@compat const NormalAttributeMesh{VT, FT, NT, AT, A_ID_T} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, AT, A_ID_T}
+@compat const GLNormalAttributeMesh = NormalAttributeMesh{Float32, GLTriangle, Float32, Vector{RGBA{U8}}, Float32}
 
-typealias NormalUVWMesh{VT, FT, NT, UVT} HMesh{Point{3, VT}, FT, Normal{3, NT}, UVW{UVT}, Void, Void, Void}
-typealias GLNormalUVWMesh NormalUVWMesh{Float32, GLTriangle, Float32, Float32}
+@compat const NormalUVWMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UVW{UVT}, Void, Void, Void}
+@compat const GLNormalUVWMesh = NormalUVWMesh{Float32, GLTriangle, Float32, Float32}
 
-typealias NormalUVMesh{VT, FT, NT, UVT} HMesh{Point{3, VT}, FT, Normal{3, NT}, UV{UVT}, Void, Void, Void}
-typealias GLNormalUVMesh NormalUVMesh{Float32, GLTriangle, Float32, Float32}
+@compat const NormalUVMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UV{UVT}, Void, Void, Void}
+@compat const GLNormalUVMesh = NormalUVMesh{Float32, GLTriangle, Float32, Float32}

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,20 +1,20 @@
-abstract AbstractDistanceField
-abstract AbstractUnsignedDistanceField <: AbstractDistanceField
-abstract AbstractSignedDistanceField <: AbstractDistanceField
+@compat abstract type AbstractDistanceField end
+@compat abstract type AbstractUnsignedDistanceField <: AbstractDistanceField end
+@compat abstract type AbstractSignedDistanceField <: AbstractDistanceField end
 """
 Abstract to categorize geometry primitives of dimensionality `N` and
 the numeric element type `T`.
 """
-abstract AbstractGeometry{N, T}
-abstract AbstractMesh{VertT, FaceT} <: AbstractGeometry
-abstract GeometryPrimitive{N, T} <: AbstractGeometry{N, T}
+@compat abstract type AbstractGeometry{N, T} end
+@compat abstract type AbstractMesh{VertT, FaceT}  end # <: AbstractGeometry
+@compat abstract type GeometryPrimitive{N, T} <: AbstractGeometry{N, T} end
 
 """
 Abstract to classify Simplices. The convention for N starts at 1, which means
 a Simplex has 1 point. A 2-simplex has 2 points, and so forth. This convention
 is not the same as most mathematical texts.
 """
-abstract AbstractSimplex{N,T} <: FixedVector{N,T}
+@compat abstract type AbstractSimplex{N,T} <: FixedVector{N,T} end
 
 
 """
@@ -157,8 +157,8 @@ AbstractFlexibleGeometry{T}
 
 AbstractFlexibleGeometry refers to shapes, which are somewhat mutable.
 """
-abstract AbstractFlexibleGeometry{T}
-typealias AFG AbstractFlexibleGeometry
+@compat abstract type AbstractFlexibleGeometry{T} end
+const AFG = AbstractFlexibleGeometry
 
 """
 FlexibleConvexHull{T}
@@ -184,5 +184,5 @@ AbstractConvexHull
 Groups all geometry types, that can be described as the convex hull of finitely
 many points.
 """
-typealias AbstractConvexHull Union{Simplex, FlexibleConvexHull, FlexibleSimplex,
-HyperCube, HyperRectangle} # should we parametrize ACH by the type of points T?
+const AbstractConvexHull = Union{Simplex, FlexibleConvexHull, FlexibleSimplex,
+                                HyperCube, HyperRectangle} # should we parametrize ACH by the type of points T?

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,5 @@
 using GeometryTypes, ColorTypes
-if VERSION >= v"0.5.0-dev+7720"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
 import Base.Test.@inferred
 
 @testset "GeometryTypes" begin
@@ -23,4 +18,3 @@ import Base.Test.@inferred
     include("gjk.jl")
     include("lines.jl")
 end
-


### PR DESCRIPTION
@SimonDanisch tests are passing on 0.5, but not on 0.6, probably because FixedSizeArrays has not been updated yet.

A minor problem
`slice` has been removed from base in favour of view. Do you want to keep that name?

A major one
```julia
abstract GeometryTypes.AbstractMesh{VertT,FaceT} <: GeometryTypes.GeometryPrimitive
```
is not allowed anymore, you cannot inherit from a union. For the time being I removed the inheritance. An option would be to add another layer of (unparametrized) abstraction above GeometryPrimitive. You can carry on from here if you want or give me some direction.

Cheers,
Carlo 