### PR TITLE
Fix mesh conversion

### DIFF
--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -48,7 +48,7 @@ function all_attributes{M <: HMesh}(m::M)
 end
 
 # Needed to not get into an stack overflow
-convert{M <: AbstractMesh}(::Type{M}, mesh::AbstractGeometry) = M(mesh)
+convert{M <: AbstractMesh}(::Type{M}, mesh::Union{AbstractGeometry, AbstractMesh}) = M(mesh)
 convert(::Type{T}, mesh::T) where T <: AbstractMesh = mesh
 #@compat (::Type{HM1}){HM1 <: AbstractMesh}(mesh::HM1) = mesh
 

--- a/test/meshes.jl
+++ b/test/meshes.jl
@@ -156,6 +156,15 @@ end
     @test all(isapprox.(ns, expect))
 end
 
+@testset "conversion" begin
+    VT = vertextype(GLNormalMesh)
+    FT = facetype(GLNormalMesh)
+    vs = [VT(0., 0, 0), VT(1., 0, 0), VT(0., 1, 0)]
+    fs = [FT(1, 2, 3)]
+    mesh = PlainMesh{eltype(VT), FT}(vertices=vs, faces=fs)
+    @test convert(GLNormalMesh, mesh) == GLNormalMesh(vs, fs)
+end
+
 end
 
 


### PR DESCRIPTION
fixes #90 

The fallback method for `convert()` for meshes assumed that `AbstractMesh <: AbstractGeometry` which is no longer the case. 