### PR TITLE
convert HomogenousMesh constructor to an @generated function to work around segfault

### DIFF
--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -79,23 +79,26 @@ end
 isvoid{T}(::Type{T}) = false
 isvoid(::Type{Void}) = true
 isvoid{T}(::Type{Vector{T}}) = isvoid(T)
-function (::Type{HM1}){HM1 <: HomogenousMesh}(primitive::HomogenousMesh)
+
+@generated function (::Type{HM1})(primitive::HM2) where {HM1 <: HomogenousMesh, HM2 <: HomogenousMesh}
     fnames = fieldnames(HM1)
-    args = ntuple(nfields(HM1)) do i
-        field, target_type = fnames[i], fieldtype(HM1, i)
-        soure_type = fieldtype(typeof(primitive), i)
-        isleaftype(fieldtype(HM1, i)) || return getfield(primitive, field) # target is not defined
-        if !isvoid(target_type) && isvoid(soure_type) # target not there yet, maybe we can decompose though (e.g. normals)
-            return decompose(HM1.parameters[i], primitive)
+    expr = Expr(:call, HM1)
+    for i in 1:nfields(HM1)
+        field = fnames[i]
+        target_type = fieldtype(HM1, i)
+        soure_type = fieldtype(HM2, i)
+        if isleaftype(fieldtype(HM1, i))  # target is not defined
+            push!(expr.args, :(getfield(primitive, $(QuoteNode(field)))))
+        elseif !isvoid(target_type) && isvoid(soure_type) # target not there yet, maybe we can decompose though (e.g. normals)
+            push!(expr.args, :(decompose($(HM1.parameters[i]), primitive)))
         elseif isvoid(target_type)
-            return target_type()
+            push!(expr.args, :($(target_type())))
         else
-            return convert(target_type, getfield(primitive, field))
+            push!(expr.args, :(convert($target_type, getfield(primitive, $(QuoteNode(field))))))
         end
     end
-    HM1(args...)
+    expr
 end
-
 
 #Should be:
 #function call{M <: HMesh, VT <: Point, FT <: Face}(::Type{M}, vertices::Vector{VT}, faces::Vector{FT})

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -86,10 +86,10 @@ isvoid{T}(::Type{Vector{T}}) = isvoid(T)
     for i in 1:nfields(HM1)
         field = fnames[i]
         target_type = fieldtype(HM1, i)
-        soure_type = fieldtype(HM2, i)
-        if isleaftype(fieldtype(HM1, i))  # target is not defined
+        source_type = fieldtype(HM2, i)
+        if !isleaftype(fieldtype(HM1, i))  # target is not defined
             push!(expr.args, :(getfield(primitive, $(QuoteNode(field)))))
-        elseif !isvoid(target_type) && isvoid(soure_type) # target not there yet, maybe we can decompose though (e.g. normals)
+        elseif !isvoid(target_type) && isvoid(source_type) # target not there yet, maybe we can decompose though (e.g. normals)
             push!(expr.args, :(decompose($(HM1.parameters[i]), primitive)))
         elseif isvoid(target_type)
             push!(expr.args, :($(target_type())))

--- a/test/meshes.jl
+++ b/test/meshes.jl
@@ -40,7 +40,16 @@ end
     #@fact readall(io) --> s #Win32 and Win64 have different ordering it seems.
 end
 
+@testset "construction" begin
+    VT = vertextype(GLNormalMesh)
+    FT = facetype(GLNormalMesh)
+    vs = [VT(0., 0, 0), VT(1., 0, 0), VT(0., 1, 0)]
+    fs = [FT(1, 2, 3)]
 
+    # test for https://github.com/JuliaGeometry/GeometryTypes.jl/issues/92
+    m = HomogenousMesh(vs, fs)
+    @test HomogenousMesh(m) == m
+end
 
 @testset "Primitives" begin
     # issue #16
@@ -154,17 +163,6 @@ end
         (0.408248,0.408248,-0.816497)
     ]
     @test all(isapprox.(ns, expect))
-end
-
-@testset "construction" begin
-    VT = vertextype(GLNormalMesh)
-    FT = facetype(GLNormalMesh)
-    vs = [VT(0., 0, 0), VT(1., 0, 0), VT(0., 1, 0)]
-    fs = [FT(1, 2, 3)]
-
-    # test for https://github.com/JuliaGeometry/GeometryTypes.jl/issues/92
-    m = HomogenousMesh(vs, fs)
-    @test HomogenousMesh(m) == m
 end
 
 end

--- a/test/meshes.jl
+++ b/test/meshes.jl
@@ -157,6 +157,11 @@ end
 end
 
 @testset "construction" begin
+    VT = vertextype(GLNormalMesh)
+    FT = facetype(GLNormalMesh)
+    vs = [VT(0., 0, 0), VT(1., 0, 0), VT(0., 1, 0)]
+    fs = [FT(1, 2, 3)]
+
     # test for https://github.com/JuliaGeometry/GeometryTypes.jl/issues/92
     m = HomogenousMesh(vs, fs)
     @test HomogenousMesh(m) == m

--- a/test/meshes.jl
+++ b/test/meshes.jl
@@ -156,6 +156,12 @@ end
     @test all(isapprox.(ns, expect))
 end
 
+@testset "construction" begin
+    # test for https://github.com/JuliaGeometry/GeometryTypes.jl/issues/92
+    m = HomogenousMesh(vs, fs)
+    @test HomogenousMesh(m) == m
+end
+
 end
 
 


### PR DESCRIPTION
The current HomogenousMesh constructor is doing a lot of reflection on its input types at runtime, and somehow that's triggering the segfault in #92. Switching it to a generated function actually seems like an improvement anyway, since it moves most of that work to compile-time, and it also fixes the segfault (for some reason). 

fixes #92