### PR TITLE
use promote_rule instead of promote_type to avoid julialang/julia#22179

### DIFF
--- a/src/faces.jl
+++ b/src/faces.jl
@@ -50,8 +50,7 @@ for op in (:(==), :(>=), :(<=))
 end
 
 
-Base.promote_type{T <: Int, OI <: OffsetInteger}(::Type{T}, ::Type{OI}) = T
-Base.promote_type{T <: Int, OI <: OffsetInteger}(::Type{OI}, ::Type{T}) = T
+Base.promote_rule{T <: Int, OI <: OffsetInteger}(::Type{T}, ::Type{OI}) = T
 
 
 @generated function Base.getindex{N}(


### PR DESCRIPTION
(and because it's the right thing to do anyway)