### PR TITLE
fully upgrade to v0.6 syntax and remove Compat.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.6.0-pre
 StaticArrays
 ColorTypes
-Compat 0.18
 FixedPointNumbers

--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -7,9 +7,6 @@ using ColorTypes
 
 import FixedPointNumbers # U8
 
-
-using Compat
-
 import Base: ==,
              *,
              contains,

--- a/src/gjk.jl
+++ b/src/gjk.jl
@@ -36,7 +36,7 @@ MinkowskiDifference(c1, c2)
 
 Represents the Minkowski difference of c1, c2.
 """
-immutable MinkowskiDifference{S,T}
+struct MinkowskiDifference{S,T}
     c1::S
     c2::T
 end

--- a/src/hyperrectangles.jl
+++ b/src/hyperrectangles.jl
@@ -161,7 +161,7 @@ end
 """
 Construct a HyperRectangle enclosing all points.
 """
-@compat function (t::Type{HyperRectangle{N1, T1}}){N1, T1, PT <: Point}(
+function (t::Type{HyperRectangle{N1, T1}}){N1, T1, PT <: Point}(
         geometry::AbstractArray{PT}
     )
     N2, T2 = length(PT), eltype(PT)

--- a/src/lines.jl
+++ b/src/lines.jl
@@ -59,7 +59,7 @@ end
 
 # Taken from Iterators.jl, since it's not possible to use Iterators.jl on 0.6 with precompilation
 
-immutable Partition{I, N}
+struct Partition{I, N}
     xs::I
     step::Int
 end

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -50,7 +50,7 @@ end
 # Needed to not get into an stack overflow
 convert{M <: AbstractMesh}(::Type{M}, mesh::AbstractGeometry) = M(mesh)
 convert(::Type{T}, mesh::T) where T <: AbstractMesh = mesh
-#@compat (::Type{HM1}){HM1 <: AbstractMesh}(mesh::HM1) = mesh
+# (::Type{HM1}){HM1 <: AbstractMesh}(mesh::HM1) = mesh
 
 """
 Uses decompose to get all the converted attributes from the meshtype and
@@ -234,7 +234,7 @@ end
 
 # Fast but slightly ugly way to implement mesh multiplication
 # This should probably go into FixedSizeArrays.jl, Vector{FSA} * FSA
-immutable MeshMulFunctor{T}
+struct MeshMulFunctor{T}
     matrix::Mat{4,4,T}
 end
 (m::MeshMulFunctor{T}){T}(vert) = Vec{3, T}(m.matrix*Vec{4, T}(vert..., 1))

--- a/src/simplices.jl
+++ b/src/simplices.jl
@@ -43,10 +43,10 @@ function StaticArrays.similar_type{T}(::Union{Simplex, Type{Simplex}}, ::Type{T}
     Simplex{s[1], T}
 end
 
-# @compat (::Type{S}){S <: Simplex}(fs::FlexibleSimplex) = convert(S, fs)
+# (::Type{S}){S <: Simplex}(fs::FlexibleSimplex) = convert(S, fs)
 #
 # # FSA doesn't handle symbols for length 1 well.
-# @compat function (::Type{T}){T <: Simplex}(f::Symbol)
+# function (::Type{T}){T <: Simplex}(f::Symbol)
 #     Simplex{1 ,Symbol}((f,))
 # end
 

--- a/src/typealias.jl
+++ b/src/typealias.jl
@@ -13,7 +13,7 @@ for i=1:4
     name   = Symbol("Mat$i")
     namef0 = Symbol("Mat$(i)f0")
     @eval begin
-        @compat const $name{T} = $Mat{$i,$i, T, $(i*i)}
+        const $name{T} = $Mat{$i,$i, T, $(i*i)}
         const $namef0 = $name{Float32}
         export $name
         export $namef0
@@ -21,40 +21,40 @@ for i=1:4
 end
 
 #Type aliases
-@compat const U8 = FixedPointNumbers.Normed{UInt8, 8}
+const U8 = FixedPointNumbers.Normed{UInt8, 8}
 
 """
 An alias for a one-simplex, corresponding to LineSegment{T} -> Simplex{2,T}.
 """
-@compat const LineSegment{T} = Simplex{2,T}
+const LineSegment{T} = Simplex{2,T}
 
-@compat const ZeroIndex{T <: Integer} = OffsetInteger{-1, T}
-@compat const OneIndex{T <: Integer} = OffsetInteger{0, T}
+const ZeroIndex{T <: Integer} = OffsetInteger{-1, T}
+const OneIndex{T <: Integer} = OffsetInteger{0, T}
 const GLIndex = ZeroIndex{Cuint}
 
-@compat const Triangle{T} = Face{3, T}
-@compat const GLFace{Dim} = Face{Dim, GLIndex} #offset is relative to julia, so -1 is 0-indexed
-@compat const GLTriangle = Face{3, GLIndex}
+const Triangle{T} = Face{3, T}
+const GLFace{Dim} = Face{Dim, GLIndex} #offset is relative to julia, so -1 is 0-indexed
+const GLTriangle = Face{3, GLIndex}
 const GLQuad = Face{4, GLIndex}
 
-@compat const Cube{T} = HyperCube{3, T}
+const Cube{T} = HyperCube{3, T}
 
 """
 An alias for a HyperSphere of dimension 2. i.e. Circle{T} -> HyperSphere{2, T}
 """
-@compat const Circle{T} = HyperSphere{2, T}
+const Circle{T} = HyperSphere{2, T}
 
 """
 An alias for a HyperSphere of dimension 3. i.e. Sphere{T} -> HyperSphere{3, T}
 """
-@compat const Sphere{T} = HyperSphere{3, T}
+const Sphere{T} = HyperSphere{3, T}
 
-@compat const AbsoluteRectangle{T} = HyperRectangle{2, T}
+const AbsoluteRectangle{T} = HyperRectangle{2, T}
 
 """
 AABB, or Axis Aligned Bounding Box, is an alias for a 3D HyperRectangle.
 """
-@compat const AABB{T} = HyperRectangle{3, T}
+const AABB{T} = HyperRectangle{3, T}
 (::Type{AABB})(m...) = HyperRectangle(m...)
 
 const HMesh = HomogenousMesh
@@ -63,48 +63,48 @@ const HMesh = HomogenousMesh
 A `Cylinder2` or `Cylinder3` is a 2D/3D cylinder defined by its origin point,
 its extremity and a radius. `origin`, `extremity` and `r`, must be specified.
 """
-@compat const Cylinder2{T} = Cylinder{2, T}
-@compat const Cylinder3{T} = Cylinder{3, T}
+const Cylinder2{T} = Cylinder{2, T}
+const Cylinder3{T} = Cylinder{3, T}
 
 
 
-@compat const UV{T} = TextureCoordinate{2, T}
-@compat const UVW{T} = TextureCoordinate{3, T}
+const UV{T} = TextureCoordinate{2, T}
+const UVW{T} = TextureCoordinate{3, T}
 
 """
 A `SimpleMesh` is an alias for a `HomogenousMesh` parameterized only by
 vertex and face types.
 """
-@compat const SimpleMesh{VT, FT} = HMesh{VT, FT, Void, Void, Void, Void, Void}
-@compat const PlainMesh{VT, FT} = HMesh{Point{3, VT}, FT, Void, Void, Void, Void, Void}
-@compat const GLPlainMesh = PlainMesh{Float32, GLTriangle}
+const SimpleMesh{VT, FT} = HMesh{VT, FT, Void, Void, Void, Void, Void}
+const PlainMesh{VT, FT} = HMesh{Point{3, VT}, FT, Void, Void, Void, Void, Void}
+const GLPlainMesh = PlainMesh{Float32, GLTriangle}
 
-@compat const Mesh2D{VT, FT} = HMesh{Point{2, VT}, FT, Void, Void, Void, Void, Void}
-@compat const GLMesh2D = Mesh2D{Float32, GLTriangle}
+const Mesh2D{VT, FT} = HMesh{Point{2, VT}, FT, Void, Void, Void, Void, Void}
+const GLMesh2D = Mesh2D{Float32, GLTriangle}
 
-@compat const UVMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Void, UV{UVT}, Void, Void, Void}
-@compat const GLUVMesh = UVMesh{Float32, GLTriangle, Float32}
+const UVMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Void, UV{UVT}, Void, Void, Void}
+const GLUVMesh = UVMesh{Float32, GLTriangle, Float32}
 
-@compat const UVWMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Void, UVW{UVT}, Void, Void, Void}
-@compat const GLUVWMesh = UVWMesh{Float32, GLTriangle, Float32}
+const UVWMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Void, UVW{UVT}, Void, Void, Void}
+const GLUVWMesh = UVWMesh{Float32, GLTriangle, Float32}
 
-@compat const NormalMesh{VT, FT, NT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, Void, Void}
-@compat const GLNormalMesh = NormalMesh{Float32, GLTriangle, Float32}
+const NormalMesh{VT, FT, NT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, Void, Void}
+const GLNormalMesh = NormalMesh{Float32, GLTriangle, Float32}
 
-@compat const UVMesh2D{VT, FT, UVT} = HMesh{Point{2, VT}, FT, Void, UV{UVT}, Void, Void, Void}
-@compat const GLUVMesh2D = UVMesh2D{Float32, GLTriangle, Float32}
+const UVMesh2D{VT, FT, UVT} = HMesh{Point{2, VT}, FT, Void, UV{UVT}, Void, Void, Void}
+const GLUVMesh2D = UVMesh2D{Float32, GLTriangle, Float32}
 
-@compat const NormalColorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, CT, Void, Void}
-@compat const GLNormalColorMesh = NormalColorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
+const NormalColorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, CT, Void, Void}
+const GLNormalColorMesh = NormalColorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
 
-@compat const NormalVertexcolorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Vector{CT}, Void, Void}
-@compat const GLNormalVertexcolorMesh = NormalVertexcolorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
+const NormalVertexcolorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Vector{CT}, Void, Void}
+const GLNormalVertexcolorMesh = NormalVertexcolorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
 
-@compat const NormalAttributeMesh{VT, FT, NT, AT, A_ID_T} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, AT, A_ID_T}
-@compat const GLNormalAttributeMesh = NormalAttributeMesh{Float32, GLTriangle, Float32, Vector{RGBA{U8}}, Float32}
+const NormalAttributeMesh{VT, FT, NT, AT, A_ID_T} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, AT, A_ID_T}
+const GLNormalAttributeMesh = NormalAttributeMesh{Float32, GLTriangle, Float32, Vector{RGBA{U8}}, Float32}
 
-@compat const NormalUVWMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UVW{UVT}, Void, Void, Void}
-@compat const GLNormalUVWMesh = NormalUVWMesh{Float32, GLTriangle, Float32, Float32}
+const NormalUVWMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UVW{UVT}, Void, Void, Void}
+const GLNormalUVWMesh = NormalUVWMesh{Float32, GLTriangle, Float32, Float32}
 
-@compat const NormalUVMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UV{UVT}, Void, Void, Void}
-@compat const GLNormalUVMesh = NormalUVMesh{Float32, GLTriangle, Float32, Float32}
+const NormalUVMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UV{UVT}, Void, Void, Void}
+const GLNormalUVMesh = NormalUVMesh{Float32, GLTriangle, Float32, Float32}

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,9 +1,9 @@
 using StaticArrays.FixedSizeArrays
 import StaticArrays.FixedSizeArrays: @fixed_vector
 
-@compat abstract type AbstractDistanceField end
-@compat abstract type AbstractUnsignedDistanceField <: AbstractDistanceField end
-@compat abstract type AbstractSignedDistanceField <: AbstractDistanceField end
+abstract type AbstractDistanceField end
+abstract type AbstractUnsignedDistanceField <: AbstractDistanceField end
+abstract type AbstractSignedDistanceField <: AbstractDistanceField end
 """
 Abstract to categorize geometry primitives of dimensionality `N` and
 the numeric element type `T`.
@@ -11,9 +11,9 @@ the numeric element type `T`.
 # abstract AbstractGeometry{N, T}
 # abstract AbstractMesh{VertT, FaceT} <: AbstractGeometry{3, Float32}
 # abstract GeometryPrimitive{N, T} <: AbstractGeometry{N, T}
-@compat abstract type AbstractGeometry{N, T} end
-@compat abstract type AbstractMesh{VertT, FaceT}  end # <: AbstractGeometry
-@compat abstract type GeometryPrimitive{N, T} <: AbstractGeometry{N, T} end
+abstract type AbstractGeometry{N, T} end
+abstract type AbstractMesh{VertT, FaceT}  end # <: AbstractGeometry
+abstract type GeometryPrimitive{N, T} <: AbstractGeometry{N, T} end
 
 
 """
@@ -21,7 +21,7 @@ Abstract to classify Simplices. The convention for N starts at 1, which means
 a Simplex has 1 point. A 2-simplex has 2 points, and so forth. This convention
 is not the same as most mathematical texts.
 """
-@compat abstract type AbstractSimplex{S, T} <: StaticVector{S, T} end
+abstract type AbstractSimplex{S, T} <: StaticVector{S, T} end
 
 
 """
@@ -40,7 +40,7 @@ This is for a simpler implementation.
 It applies to infinite dimensions. The structure of this type is designed
 to allow embedding in higher-order spaces by parameterizing on `T`.
 """
-immutable Simplex{S, T} <: AbstractSimplex{S, T}
+struct Simplex{S, T} <: AbstractSimplex{S, T}
     data::NTuple{S, T}
     (::Type{Simplex{S, T}}){S, T}(x::NTuple{S, T}) = new{S, T}(x)
     (::Type{Simplex{S, T}}){S, T}(x::NTuple{S}) = new{S, T}(StaticArrays.convert_ntuple(T, x))
@@ -72,7 +72,7 @@ OffsetInteger type mainly for indexing.
 * `O` - The offset relative to Julia arrays. This helps reduce copying when
 communicating with 0-indexed systems such ad OpenGL.
 """
-immutable OffsetInteger{O, T <: Integer} <: Integer
+struct OffsetInteger{O, T <: Integer} <: Integer
     i::T
     
     OffsetInteger{O, T}(x::Integer) where {O, T <: Integer} = new{O, T}(T(x + O))
@@ -87,13 +87,13 @@ A `HyperRectangle` is a generalization of a rectangle into N-dimensions.
 Formally it is the cartesian product of intervals, which is represented by the
 `origin` and `width` fields, whose indices correspond to each of the `N` axes.
 """
-immutable HyperRectangle{N, T} <: GeometryPrimitive{N, T}
+struct HyperRectangle{N, T} <: GeometryPrimitive{N, T}
     origin::Vec{N, T}
     widths::Vec{N, T}
 end
 
 
-immutable HyperCube{N, T} <: GeometryPrimitive{N, T}
+struct HyperCube{N, T} <: GeometryPrimitive{N, T}
     origin::Vec{N, T}
     width::T
 end
@@ -103,12 +103,12 @@ end
 A `HyperSphere` is a generalization of a sphere into N-dimensions.
 A `center` and radius, `r`, must be specified.
 """
-immutable HyperSphere{N, T} <: GeometryPrimitive{N, T}
+struct HyperSphere{N, T} <: GeometryPrimitive{N, T}
     center::Point{N, T}
     r::T
 end
 
-immutable SimpleRectangle{T} <: GeometryPrimitive{2, T}
+struct SimpleRectangle{T} <: GeometryPrimitive{2, T}
     x::T
     y::T
     w::T
@@ -121,19 +121,19 @@ const Rectangle = SimpleRectangle
 """
 A rectangle in 3D space.
 """
-immutable Quad{T} <: GeometryPrimitive{3, T}
+struct Quad{T} <: GeometryPrimitive{3, T}
     downleft::Vec{3, T}
     width   ::Vec{3, T}
     height  ::Vec{3, T}
 end
 
-immutable Pyramid{T} <: GeometryPrimitive{3, T}
+struct Pyramid{T} <: GeometryPrimitive{3, T}
     middle::Point{3, T}
     length::T
     width ::T
 end
 
-immutable Particle{N, T} <: GeometryPrimitive{N, T}
+struct Particle{N, T} <: GeometryPrimitive{N, T}
     position::Point{N, T}
     velocity::Vec{N, T}
 end
@@ -152,7 +152,7 @@ The type is parameterized by:
 Note that decoupling the space and field types is useful since geometry can
 be formulated with integers and distances can be measured with floating points.
 """
-type SignedDistanceField{N,SpaceT,FieldT} <: AbstractSignedDistanceField
+mutable struct SignedDistanceField{N,SpaceT,FieldT} <: AbstractSignedDistanceField
     bounds::HyperRectangle{N,SpaceT}
     data::Array{FieldT,N}
 end
@@ -166,7 +166,7 @@ one mesh type.
 This is not perfect, but helps to reduce a type explosion (imagine defining
 every attribute combination as a new type).
 """
-immutable HomogenousMesh{VertT, FaceT, NormalT, TexCoordT, ColorT, AttribT, AttribIDT} <: AbstractMesh{VertT, FaceT}
+struct HomogenousMesh{VertT, FaceT, NormalT, TexCoordT, ColorT, AttribT, AttribIDT} <: AbstractMesh{VertT, FaceT}
     vertices            ::Vector{VertT}
     faces               ::Vector{FaceT}
     normals             ::Vector{NormalT}
@@ -181,7 +181,7 @@ AbstractFlexibleGeometry{T}
 
 AbstractFlexibleGeometry refers to shapes, which are somewhat mutable.
 """
-@compat abstract type AbstractFlexibleGeometry{T} end
+abstract type AbstractFlexibleGeometry{T} end
 const AFG = AbstractFlexibleGeometry
 
 """
@@ -189,7 +189,7 @@ FlexibleConvexHull{T}
 
 Represents the convex hull of finitely many points. The number of points is not fixed.
 """
-immutable FlexibleConvexHull{T} <: AFG{T}
+struct FlexibleConvexHull{T} <: AFG{T}
     _::Vector{T}
 end
 
@@ -198,7 +198,7 @@ FlexibleSimplex{T}
 
 Represents a Simplex whos number of vertices is not fixed.
 """
-immutable FlexibleSimplex{T} <: AFG{T}
+struct FlexibleSimplex{T} <: AFG{T}
     _::Vector{T}
 end
 
@@ -206,7 +206,7 @@ end
 A `Cylinder` is a 2D rectangle or a 3D cylinder defined by its origin point,
 its extremity and a radius. `origin`, `extremity` and `r`, must be specified.
 """
-immutable Cylinder{N,T<: AbstractFloat} <: GeometryPrimitive{N,T}
+struct Cylinder{N,T<: AbstractFloat} <: GeometryPrimitive{N,T}
     origin::Point{N,T}
     extremity::Point{N,T}
     r::T

--- a/src/typeutils.jl
+++ b/src/typeutils.jl
@@ -1,5 +1,3 @@
-using Compat.TypeUtils
-
 eltype_or(::Type{G}, or) where G <: (AbstractGeometry{N, T} where N) where T = T
 eltype_or(::Type{G}, or) where G <: (AbstractGeometry{N, T} where {N, T}) = or
 


### PR DESCRIPTION
Sorry for the crazy number of PRs today. I've been busy 😉 and wanted to keep the various changes as small and discrete as possible. 

This removes all the compatibility clutter and fully upgrades to v0.6 syntax. It should prevent deprecation warnings on the v0.7 nightlies ~~(but the nightly tests will fail until #95 #97  comes in first).~~