### PR TITLE
Require Normed v0.3

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.6.0-pre
 StaticArrays
 ColorTypes
 Compat 0.18
-FixedPointNumbers
+FixedPointNumbers 0.3


### PR DESCRIPTION
`Normed` requires FixedPointNumbers v0.3 as pointed out by @tkelman 