### PR TITLE
fix InexactErrors due to promotion to unsigned integer types

### DIFF
--- a/src/faces.jl
+++ b/src/faces.jl
@@ -1,7 +1,7 @@
 import Base: +, -, abs, *, /, div, convert, ==, <=, >=, show, to_index
 
 function show{O, T}(io::IO, oi::OffsetInteger{O, T})
-    print(io, "|$(raw(oi)) (indexes as $(raw(oi) + -O))|")
+    print(io, "|$(raw(oi)) (indexes as $(O >= 0 ? raw(oi) - O : raw(oi) + -O))|")
 end
 
 Base.eltype(::Type{OffsetInteger{O, T}}) where {O, T} = T

--- a/src/types.jl
+++ b/src/types.jl
@@ -75,7 +75,7 @@ communicating with 0-indexed systems such ad OpenGL.
 struct OffsetInteger{O, T <: Integer} <: Integer
     i::T
 
-    OffsetInteger{O, T}(x::Integer) where {O, T <: Integer} = new{O, T}(T(x + O))
+    OffsetInteger{O, T}(x::Integer) where {O, T <: Integer} = new{O, T}(T(O >= 0 ? x + O : x - (-O)))
 end
 
 

--- a/test/faces.jl
+++ b/test/faces.jl
@@ -28,4 +28,12 @@
         vf = [vs[face] for face in faces(x)]
         @test v == vf
     end
+
+    @testset "negative offests and unsigned integers" begin
+        oi = OffsetInteger{-1, UInt64}(UInt64(1))
+        show(IOBuffer(), oi)
+
+        oi = OffsetInteger{1, UInt64}(UInt64(1))
+        show(IOBuffer(), oi)
+    end
 end


### PR DESCRIPTION
This fixes the errors on win32 in https://github.com/JuliaIO/MeshIO.jl/pull/31

The problem is that the following works:

```julia
julia> UInt64(1) - 1
0x0000000000000000
```

but adding `-1` fails, because Julia tries to promote both arguments to `UInt64`:

```julia
julia> UInt64(1) + -1
ERROR: InexactError()
```

So we just have to add or subtract appropriately depending on the sign of the offset. 