### PR TITLE
Correct deprecated syntax for map! in meshes.jl. Resolves issue #118.

### DIFF
--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -220,6 +220,6 @@ end
 (m::MeshMulFunctor{T})(vert) where {T} = Vec{3, T}(m.matrix*Vec{4, T}(vert..., 1))
 function *(m::Mat{4,4,T}, mesh::AbstractMesh) where T
     msh = deepcopy(mesh)
-    map!(MeshMulFunctor(m), msh.vertices)
+    map!(MeshMulFunctor(m), msh.vertices, msh.vertices)
     msh
 end


### PR DESCRIPTION
Simple fix, updates deprecated syntax and addresses both issue #118 and the corresponding issue in GLVisualize.jl.