### PR TITLE
Fix tests and most deprecations on v0.7-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ matrix:
 notifications:
   email: false
 sudo: false
+
+after_success:
+  - julia -e 'cd(Pkg.dir("GeometryTypes")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ julia:
 
 matrix:
   allow_failures:
+    - julia: 0.7
     - julia: nightly
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ os:
   - osx
 julia:
   - 0.6
+  - 0.7
   - nightly
- 
+
 matrix:
   allow_failures:
     - julia: nightly

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ end
 
 function decompose{T<:Face}(::Type{T}, r::SimpleRectangle, resolution=(2,2))
     w,h = resolution
+    Idx = LinearIndices(resolution) # Compat.LinearIndices in Julia v0.6 and below
     faces = vec([Face{4, Int}(
-            sub2ind(resolution, i, j), sub2ind(resolution, i+1, j),
-            sub2ind(resolution, i+1, j+1), sub2ind(resolution, i, j+1)
+            Idx[i, j], Idx[i+1, j],
+            Idx[i+1, j+1], Idx[i, j+1]
         ) for i=1:(w-1), j=1:(h-1)]
     )
     decompose(T, faces)

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ IterTools
 StaticArrays 0.5.1
 ColorTypes 0.3.1
 FixedPointNumbers 0.3
+Compat 0.33 

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,4 +4,4 @@ IterTools
 StaticArrays 0.5.1
 ColorTypes 0.3.1
 FixedPointNumbers 0.3
-Compat 0.33 
+Compat 0.59

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,11 @@ notifications:
 
 install:
   - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
+  # If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile(
         $env:JULIA_URL,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ branches:
 
 matrix:
   allow_failures:
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/docs/build/types.md
+++ b/docs/build/types.md
@@ -43,7 +43,7 @@ An alias for a HyperSphere of dimension 3. i.e. Sphere{T} -> HyperSphere{3, T}
 
 <a name="GeometryTypes.HomogenousMesh"></a>
 
-The `HomogenousMesh` type describes a polygonal mesh that is useful for computation on the CPU or on the GPU. All vectors must have the same length or must be empty, besides the face vector Type can be void or a value, this way we can create many combinations from this one mesh type. This is not perfect, but helps to reduce a type explosion (imagine defining every attribute combination as a new type).
+The `HomogenousMesh` type describes a polygonal mesh that is useful for computation on the CPU or on the GPU. All vectors must have the same length or must be empty, besides the face vector Type can be Void or a value, this way we can create many combinations from this one mesh type. This is not perfect, but helps to reduce a type explosion (imagine defining every attribute combination as a new type).
 
 ### Faces
 

--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -4,7 +4,7 @@ module GeometryTypes
 using StaticArrays
 using StaticArrays.FixedSizeArrays
 using ColorTypes
-using Compat: fieldcount, isconcretetype, LinearIndices, Nothing
+using Compat: fieldcount, isconcretetype, LinearIndices, Nothing, undef
 using Compat.LinearAlgebra
 
 import FixedPointNumbers # U8

--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -4,7 +4,7 @@ module GeometryTypes
 using StaticArrays
 using StaticArrays.FixedSizeArrays
 using ColorTypes
-using Compat: fieldcount, isconcretetype, LinearIndices
+using Compat: fieldcount, isconcretetype, LinearIndices, Nothing
 using Compat.LinearAlgebra
 
 import FixedPointNumbers # U8

--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -4,6 +4,8 @@ module GeometryTypes
 using StaticArrays
 using StaticArrays.FixedSizeArrays
 using ColorTypes
+using Compat: fieldcount, isconcretetype, LinearIndices
+using Compat.LinearAlgebra
 
 import FixedPointNumbers # U8
 

--- a/src/GeometryTypes.jl
+++ b/src/GeometryTypes.jl
@@ -4,7 +4,7 @@ module GeometryTypes
 using StaticArrays
 using StaticArrays.FixedSizeArrays
 using ColorTypes
-using Compat: fieldcount, isconcretetype, LinearIndices, Nothing, undef
+using Compat: fieldcount, isconcretetype, LinearIndices, Nothing, undef, range
 using Compat.LinearAlgebra
 
 import FixedPointNumbers # U8

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -1,3 +1,13 @@
+# Handle https://github.com/JuliaLang/julia/pull/23750
+@static if VERSION >= v"0.7.0-DEV.2083"
+    _reshape_reinterpret(T, X, d...) = reshape(reinterpret(T, X), d...)
+else
+    _reshape_reinterpret(T, X, d...) = reinterpret(T, X, d...)
+end
+# TODO: when we drop support for Julia v0.6, change all instances of
+# _reshape_reinterpret(T, X, d...) to reshape(reinterpret(T, X), d...)
+
+
 """
 Allow to call decompose with unspecified vector type and infer types from
 primitive.
@@ -148,7 +158,7 @@ function decompose(
     w = widths(rect)
     o = origin(rect)
     points = T1[o[j]+((i>>(j-1))&1)*w[j] for j=1:N, i=0:(2^N-1)]
-    reshape(reinterpret(PT, points), (2^N,))
+    _reshape_reinterpret(PT, points, (2^N,))
 end
 """
 Get decompose a `HyperRectangle` into Texture Coordinates.
@@ -161,7 +171,7 @@ function decompose(
     w = Vec{3,T1}(1)
     o = Vec{3,T1}(0)
     points = T1[((i>>(j-1))&1) for j=1:N, i=0:(2^N-1)]
-    reshape(reinterpret(UVWT, points), (8,))
+    _reshape_reinterpret(UVWT, points, (8,))
 end
 decompose(::Type{FT}, faces::Vector{FT}) where {FT<:Face} = faces
 function decompose(::Type{FT1}, faces::Vector{FT2}) where {FT1<:Face, FT2<:Face}

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -300,7 +300,7 @@ function decompose(T::Type{Normal{3, NT}}, mesh::AbstractMesh) where NT
     n = mesh.normals
     eltype(n) == T && return n
     eltype(n) <: Normal{3} && return map(T, n)
-    (n == Void[] || isempty(n)) && return normals(vertices(mesh), faces(mesh), T)
+    (n == Nothing[] || isempty(n)) && return normals(vertices(mesh), faces(mesh), T)
 end
 
 #Gets the uv attribute to a mesh, or creates it, or converts it
@@ -308,7 +308,7 @@ function decompose(::Type{UV{UVT}}, mesh::AbstractMesh) where UVT
     uv = mesh.texturecoordinates
     eltype(uv) == UV{UVT} && return uv
     (eltype(uv) <: UV || eltype(uv) <: UVW) && return map(UV{UVT}, uv)
-    eltype(uv) == Void && return zeros(UV{UVT}, length(vertices(mesh)))
+    eltype(uv) == Nothing && return zeros(UV{UVT}, length(vertices(mesh)))
 end
 
 

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -148,7 +148,7 @@ function decompose(
     w = widths(rect)
     o = origin(rect)
     points = T1[o[j]+((i>>(j-1))&1)*w[j] for j=1:N, i=0:(2^N-1)]
-    reinterpret(PT, points, (2^N,))
+    reshape(reinterpret(PT, points), (2^N,))
 end
 """
 Get decompose a `HyperRectangle` into Texture Coordinates.
@@ -161,7 +161,7 @@ function decompose(
     w = Vec{3,T1}(1)
     o = Vec{3,T1}(0)
     points = T1[((i>>(j-1))&1) for j=1:N, i=0:(2^N-1)]
-    reinterpret(UVWT, points, (8,))
+    reshape(reinterpret(UVWT, points), (8,))
 end
 decompose(::Type{FT}, faces::Vector{FT}) where {FT<:Face} = faces
 function decompose(::Type{FT1}, faces::Vector{FT2}) where {FT1<:Face, FT2<:Face}
@@ -169,7 +169,7 @@ function decompose(::Type{FT1}, faces::Vector{FT2}) where {FT1<:Face, FT2<:Face}
     N1,N2 = length(FT1), length(FT2)
 
     n = length(decompose(FT1, first(faces)))
-    outfaces = Vector{FT1}(length(faces)*n)
+    outfaces = Vector{FT1}(undef, length(faces)*n)
     i = 1
     for face in faces
         for outface in decompose(FT1, face)
@@ -200,24 +200,25 @@ end
 
 function decompose(P::Type{Point{2, PT}}, r::SimpleRectangle, resolution=(2,2)) where PT
     w, h = resolution
-    vec(P[(x,y) for x=linspace(r.x, r.x+r.w, w), y=linspace(r.y, r.y+r.h, h)])
+    vec(P[(x,y) for x=range(r.x, stop=r.x+r.w, length=w), y=range(r.y, stop=r.y+r.h, length=h)])
 end
 function decompose(P::Type{Point{3, PT}}, r::SimpleRectangle, resolution=(2,2)) where PT
     w, h = resolution
-    vec(P[(x, y, 0) for x = linspace(r.x, r.x+r.w, w), y = linspace(r.y, r.y+r.h, h)])
+    vec(P[(x, y, 0) for x = range(r.x, stop=r.x+r.w, length=w), y = range(r.y, stop=r.y+r.h, length=h)])
 end
 function decompose(T::Type{UV{UVT}}, r::SimpleRectangle, resolution=(2,2)) where UVT
     w,h = resolution
-    vec(T[(x, y) for x = linspace(0, 1, w), y = linspace(1, 0, h)])
+    vec(T[(x, y) for x = range(0, stop=1, length=w), y = range(1, stop=0, length=h)])
 end
 function decompose(::Type{T}, r::SimpleRectangle, resolution=(2,2)) where T<:Normal
     fill(T(0,0,1), prod(resolution))
 end
 function decompose(::Type{T}, r::SimpleRectangle, resolution=(2,2)) where T<:Face
     w,h = resolution
+    Idx = LinearIndices(resolution)
     faces = vec([Face{4, Int}(
-            sub2ind(resolution, i, j), sub2ind(resolution, i+1, j),
-            sub2ind(resolution, i+1, j+1), sub2ind(resolution, i, j+1)
+            Idx[i, j], Idx[i+1, j],
+            Idx[i+1, j+1], Idx[i, j+1]
         ) for i=1:(w-1), j=1:(h-1)]
     )
     decompose(T, faces)
@@ -355,7 +356,7 @@ end
 
 function decompose(PT::Type{Point{2,T}}, s::Circle, n=64) where T
     rad = radius(s)
-    map(linspace(T(0), T(2pi), n)) do fi
+    map(range(T(0), stop=T(2pi), length=n)) do fi
         PT(
             rad*sin(fi + pi),
             rad*cos(fi + pi)
@@ -364,12 +365,12 @@ function decompose(PT::Type{Point{2,T}}, s::Circle, n=64) where T
 end
 
 function decompose(PT::Type{Point{N,T}}, s::Sphere, facets = 24) where {N,T}
-    vertices = Vector{PT}(facets*facets+1)
+    vertices = Vector{PT}(undef, facets*facets+1)
     vertices[end] = PT(s.center) - PT(0,0,radius(s)) #Create a vertex for last triangle fan
     for j = 1:facets
         theta = T((pi*(j-1))/facets)
         for i = 1:facets
-            position = sub2ind((facets,), j, i)
+            position = (i - 1) * facets + j
             phi = T((2*pi*(i-1))/facets)
             vertices[position] = (spherical(theta, phi)*T(s.r))+PT(s.center)
         end
@@ -393,17 +394,17 @@ function decompose(::Type{FT}, s::Sphere, facets = 24) where FT <: Face
 end
 
 function decompose(::Type{FT}, s::Sphere, facets = 24) where FT <: Face{3}
-    indexes          = Vector{FT}(facets * facets * 2)
+    indexes          = Vector{FT}(undef, facets * facets * 2)
     FTE              = eltype(FT)
     psydo_triangle_i = facets*facets+1
     index            = 1
     for j=1:facets
         for i=1:facets
             next_index = mod1(i+1, facets)
-            i1 = sub2ind((facets,), j, i)
-            i2 = sub2ind((facets,), j, next_index)
-            i3 = (j != facets) ? sub2ind((facets,), j + 1, i) : psydo_triangle_i
-            i6 = (j != facets) ? sub2ind((facets,), j + 1, next_index) : psydo_triangle_i
+            i1 = (i - 1) * facets + j
+            i2 = (next_index - 1) * facets + j
+            i3 = (j != facets) ? ((i - 1) * facets + (j + 1)) : psydo_triangle_i
+            i6 = (j != facets) ? ((next_index - 1) * facets + (j + 1)) : psydo_triangle_i
             indexes[index] = FT(i2, i1, i3) # convert to required Face index offset
             indexes[index + 1] = FT(i2, i3, i6)
             index += 2
@@ -431,7 +432,7 @@ function decompose(PT::Type{Point{3,T}}, c::Cylinder{3, T}, resolution = 5) wher
     isodd(resolution) && (resolution = 2 * div(resolution, 2))
     resolution = max(8, resolution); nbv = div(resolution, 2)
     M = rotation(c); h = height(c)
-    position = 1; vertices = Vector{PT}(2 * nbv)
+    position = 1; vertices = Vector{PT}(undef, 2 * nbv)
     for j = 1:nbv
         phi = T((2π * (j - 1)) / nbv)
         vertices[position] = PT(M * Point{3, T}(c.r * cos(phi), c.r * sin(phi),0)) + PT(c.origin)
@@ -448,7 +449,7 @@ end
 function decompose(::Type{FT}, c::Cylinder{3, T}, facets = 18) where {FT <: Face, T}
     isodd(facets) ? facets = 2 * div(facets, 2) : nothing
     facets < 8 ? facets = 8 : nothing; nbv = Int(facets / 2)
-    indexes = Vector{FT}(facets); index = 1
+    indexes = Vector{FT}(undef, facets); index = 1
     for j = 1:(nbv-1)
         indexes[index] = (index + 2, index + 1, index)
         indexes[index + 1] = ( index + 3, index + 1, index + 2)

--- a/src/distancefields.jl
+++ b/src/distancefields.jl
@@ -28,7 +28,7 @@ function SignedDistanceField(f::Function,
     ny = ceil(Int, y_rng/resolution)
     nz = ceil(Int, z_rng/resolution)
 
-    vol = Array{fieldT}(nx+1, ny+1, nz+1)
+    vol = Array{fieldT}(undef, nx+1, ny+1, nz+1)
 
     nb_max = Vec(x_min + resolution*nx,
                  y_min + resolution*ny,
@@ -57,7 +57,7 @@ function SignedDistanceField(f::Function,
     nx = ceil(Int, x_rng/resolution)
     ny = ceil(Int, y_rng/resolution)
 
-    vol = Array{fieldT}(nx+1, ny+1)
+    vol = Array{fieldT}(undef, nx+1, ny+1)
 
     nb_max = Vec(x_min + resolution*nx,
                  y_min + resolution*ny)

--- a/src/hyperrectangles.jl
+++ b/src/hyperrectangles.jl
@@ -86,7 +86,7 @@ function *(m::Mat{N1,N1,T1}, h::HyperRectangle{N2, T2}) where {N1,N2,T1,T2}
     # get all points on the HyperRectangle
     d = decompose(Point, h)
     # make sure our points are sized for the tranform
-    pts = (Vec{N1, T}[vcat(pt, ones(Vec{D, T})) for pt in d]...)::NTuple{2^N2,Vec{N1,T}}
+    pts = (Vec{N1, T}[vcat(pt, ones(Vec{D, T})) for pt in d]...,)::NTuple{2^N2,Vec{N1,T}}
 
     vmin = Vec{N1, T}(typemax(T))
     vmax = Vec{N1, T}(typemin(T))

--- a/src/lines.jl
+++ b/src/lines.jl
@@ -48,7 +48,7 @@ end
 
 
 function simple_concat(vec, range, endpoint::P) where P
-    result = Vector{P}(length(range)+1)
+    result = Vector{P}(undef, length(range)+1)
     for (i,j) in enumerate(range)
         result[i] = vec[mod1(j, length(vec))]
     end

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -9,11 +9,11 @@ for (i, field) in enumerate((:vertextype, :facetype, :normaltype,
     end
 end
 
-hasvertices(msh) = vertextype(msh) != Void
-hasfaces(msh) = facetype(msh) != Void
-hasnormals(msh) = normaltype(msh) != Void
-hastexturecoordinates(msh) = texturecoordinatetype(msh) != Void
-hascolors(msh) = colortype(msh) != Void
+hasvertices(msh) = vertextype(msh) != Nothing
+hasfaces(msh) = facetype(msh) != Nothing
+hasnormals(msh) = normaltype(msh) != Nothing
+hastexturecoordinates(msh) = texturecoordinatetype(msh) != Nothing
+hascolors(msh) = colortype(msh) != Nothing
 
 vertices(msh) = msh.vertices
 faces(msh) = msh.faces
@@ -28,16 +28,16 @@ function attributes_noVF(m::T) where T <: AbstractMesh
         field => getfield(m, field)
     end)
     return filter(fielddict) do key,val
-        val != nothing && val != Void[]
+        val != nothing && val != Nothing[]
     end
 end
-#Gets all non Void attributes from a mesh in form of a Dict fieldname => value
+#Gets all non Nothing attributes from a mesh in form of a Dict fieldname => value
 function attributes(m::AbstractMesh)
-    filter((key,val) -> (val != nothing && val != Void[]), all_attributes(m))
+    filter((key,val) -> (val != nothing && val != Nothing[]), all_attributes(m))
 end
-#Gets all non Void attributes types from a mesh type fieldname => ValueType
+#Gets all non Nothing attributes types from a mesh type fieldname => ValueType
 function attributes(m::Type{M}) where M <: HMesh
-    filter((key,val) -> (val != Void && val != Vector{Void}), all_attributes(M))
+    filter((key,val) -> (val != Nothing && val != Vector{Nothing}), all_attributes(M))
 end
 
 function all_attributes(m::Type{M}) where M <: HMesh
@@ -54,7 +54,7 @@ convert(::Type{T}, mesh::T) where T <: AbstractMesh = mesh
 
 
 isvoid(::Type{T}) where {T} = false
-isvoid(::Type{Void}) = true
+isvoid(::Type{Nothing}) = true
 isvoid(::Type{Vector{T}}) where {T} = isvoid(T)
 
 @generated function (::Type{HM1})(primitive::HM2) where {HM1 <: HomogenousMesh, HM2 <: HomogenousMesh}
@@ -87,7 +87,7 @@ function (::Type{M})(
     convert(M, msh)
 end
 get_default(x::Union{Type, TypeVar}) = nothing
-get_default(x::Type{X}) where {X <: Array} = Void[]
+get_default(x::Type{X}) where {X <: Array} = Nothing[]
 
 """
 generic constructor for abstract HomogenousMesh, infering the types from the keywords (which have to match the field names)
@@ -112,7 +112,7 @@ Creates a new mesh from a dict of `fieldname => value` and converts the types to
 function (::Type{M})(attribs::Dict{Symbol, Any}) where M <: HMesh
     newfields = map(fieldnames(HomogenousMesh)) do field
         target_type = fieldtype(M, field)
-        default = fieldtype(HomogenousMesh, field) <: Vector ? Void[] : nothing
+        default = fieldtype(HomogenousMesh, field) <: Vector ? Nothing[] : nothing
         get(attribs, field, default)
     end
     M(HomogenousMesh(newfields...))
@@ -135,7 +135,7 @@ function (::Type{HM})(mesh::AbstractMesh, constattrib::ConstAttrib) where {HM <:
     for (field, target_type) in zip(fieldnames(HM), HM.parameters)
         if target_type <: ConstAttrib
             result[field] = constattrib
-        elseif target_type != Void
+        elseif target_type != Nothing
             result[field] = decompose(target_type, mesh)
         end
     end
@@ -209,7 +209,7 @@ function merge(
     attribs[:faces]         = faces
     attribs[:attributes]    = color_attrib
     attribs[:attribute_id]  = index
-    return HMesh{_1, _2, _3, _4, Void, typeof(color_attrib), eltype(index)}(attribs)
+    return HMesh{_1, _2, _3, _4, Nothing, typeof(color_attrib), eltype(index)}(attribs)
 end
 
 # Fast but slightly ugly way to implement mesh multiplication

--- a/src/typealias.jl
+++ b/src/typealias.jl
@@ -75,36 +75,36 @@ const UVW{T} = TextureCoordinate{3, T}
 A `SimpleMesh` is an alias for a `HomogenousMesh` parameterized only by
 vertex and face types.
 """
-const SimpleMesh{VT, FT} = HMesh{VT, FT, Void, Void, Void, Void, Void}
-const PlainMesh{VT, FT} = HMesh{Point{3, VT}, FT, Void, Void, Void, Void, Void}
+const SimpleMesh{VT, FT} = HMesh{VT, FT, Nothing, Nothing, Nothing, Nothing, Nothing}
+const PlainMesh{VT, FT} = HMesh{Point{3, VT}, FT, Nothing, Nothing, Nothing, Nothing, Nothing}
 const GLPlainMesh = PlainMesh{Float32, GLTriangle}
 
-const Mesh2D{VT, FT} = HMesh{Point{2, VT}, FT, Void, Void, Void, Void, Void}
+const Mesh2D{VT, FT} = HMesh{Point{2, VT}, FT, Nothing, Nothing, Nothing, Nothing, Nothing}
 const GLMesh2D = Mesh2D{Float32, GLTriangle}
 
-const UVMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Void, UV{UVT}, Void, Void, Void}
+const UVMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Nothing, UV{UVT}, Nothing, Nothing, Nothing}
 const GLUVMesh = UVMesh{Float32, GLTriangle, Float32}
 
-const UVWMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Void, UVW{UVT}, Void, Void, Void}
+const UVWMesh{VT, FT, UVT} = HMesh{Point{3, VT}, FT, Nothing, UVW{UVT}, Nothing, Nothing, Nothing}
 const GLUVWMesh = UVWMesh{Float32, GLTriangle, Float32}
 
-const NormalMesh{VT, FT, NT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, Void, Void}
+const NormalMesh{VT, FT, NT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Nothing, Nothing, Nothing, Nothing}
 const GLNormalMesh = NormalMesh{Float32, GLTriangle, Float32}
 
-const UVMesh2D{VT, FT, UVT} = HMesh{Point{2, VT}, FT, Void, UV{UVT}, Void, Void, Void}
+const UVMesh2D{VT, FT, UVT} = HMesh{Point{2, VT}, FT, Nothing, UV{UVT}, Nothing, Nothing, Nothing}
 const GLUVMesh2D = UVMesh2D{Float32, GLTriangle, Float32}
 
-const NormalColorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, CT, Void, Void}
+const NormalColorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Nothing, CT, Nothing, Nothing}
 const GLNormalColorMesh = NormalColorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
 
-const NormalVertexcolorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Vector{CT}, Void, Void}
+const NormalVertexcolorMesh{VT, FT, NT, CT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Nothing, Vector{CT}, Nothing, Nothing}
 const GLNormalVertexcolorMesh = NormalVertexcolorMesh{Float32, GLTriangle, Float32, RGBA{Float32}}
 
-const NormalAttributeMesh{VT, FT, NT, AT, A_ID_T} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Void, Void, AT, A_ID_T}
+const NormalAttributeMesh{VT, FT, NT, AT, A_ID_T} = HMesh{Point{3, VT}, FT, Normal{3, NT}, Nothing, Nothing, AT, A_ID_T}
 const GLNormalAttributeMesh = NormalAttributeMesh{Float32, GLTriangle, Float32, Vector{RGBA{U8}}, Float32}
 
-const NormalUVWMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UVW{UVT}, Void, Void, Void}
+const NormalUVWMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UVW{UVT}, Nothing, Nothing, Nothing}
 const GLNormalUVWMesh = NormalUVWMesh{Float32, GLTriangle, Float32, Float32}
 
-const NormalUVMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UV{UVT}, Void, Void, Void}
+const NormalUVMesh{VT, FT, NT, UVT} = HMesh{Point{3, VT}, FT, Normal{3, NT}, UV{UVT}, Nothing, Nothing, Nothing}
 const GLNormalUVMesh = NormalUVMesh{Float32, GLTriangle, Float32, Float32}

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,13 +4,11 @@ import StaticArrays.FixedSizeArrays: @fixed_vector
 abstract type AbstractDistanceField end
 abstract type AbstractUnsignedDistanceField <: AbstractDistanceField end
 abstract type AbstractSignedDistanceField <: AbstractDistanceField end
+
 """
 Abstract to categorize geometry primitives of dimensionality `N` and
 the numeric element type `T`.
 """
-# abstract AbstractGeometry{N, T}
-# abstract AbstractMesh{VertT, FaceT} <: AbstractGeometry{3, Float32}
-# abstract GeometryPrimitive{N, T} <: AbstractGeometry{N, T}
 abstract type AbstractGeometry{N, T} end
 abstract type AbstractMesh{VertT, FaceT}  end # <: AbstractGeometry
 abstract type GeometryPrimitive{N, T} <: AbstractGeometry{N, T} end
@@ -161,7 +159,7 @@ end
 The `HomogenousMesh` type describes a polygonal mesh that is useful for
 computation on the CPU or on the GPU.
 All vectors must have the same length or must be empty, besides the face vector
-Type can be void or a value, this way we can create many combinations from this
+Type can be Void or a value, this way we can create many combinations from this
 one mesh type.
 This is not perfect, but helps to reduce a type explosion (imagine defining
 every attribute combination as a new type).

--- a/test/lines.jl
+++ b/test/lines.jl
@@ -34,7 +34,7 @@
         @test length(polys[2]) == 15
 
 
-        u = linspace(0, 2pi, 200)
+        u = range(0, stop=2pi, length=200)
         points = Point2f0[(sin(x), sin(2x)) for x in u]
 
         inds, intersects = self_intersections(points)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using GeometryTypes, ColorTypes
-using Base.Test
-import Base.Test.@inferred
+using Compat.Test
+using Compat.Test: @inferred
 
 
 @testset "GeometryTypes" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using GeometryTypes, ColorTypes
 using Compat
+using Compat: range
 using Compat.Test
 using Compat.Test: @inferred
 using Compat.LinearAlgebra

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using GeometryTypes, ColorTypes
+using Compat
 using Compat.Test
 using Compat.Test: @inferred
+using Compat.LinearAlgebra
 
 
 @testset "GeometryTypes" begin

--- a/test/simplerectangle.jl
+++ b/test/simplerectangle.jl
@@ -31,9 +31,9 @@ end
 
 @testset "indexing" begin
     r = SimpleRectangle(0,0,2,2)
-    a = eye(4)
-    @test a[r] == eye(2)
-    a[r] = eye(2)*2
+    a = Matrix(1.0I, 4, 4)
+    @test a[r] == Matrix(1.0I, 2, 2)
+    a[r] = Matrix(I, 2, 2)*2
     @test a == [2 0 0 0; 0 2 0 0; 0 0 1 0; 0 0 0 1]
 end
 


### PR DESCRIPTION
The only outright failures on v0.7 were where we were abusing `sub2ind((v,), j, i)` by passing it a 1-dimensional first argument and then indexing with two dimensions. I replaced those calls with `(i - 1) * v + j`. 

The remaining deprecations are all due to constructors no longer falling back to convert methods. I'm still trying to figure out the right way to handle that: https://discourse.julialang.org/t/recommended-style-for-conversion-vs-constructors-in-v0-7/11561