### PR TITLE
create constructors instead of convert methods for OffsetInteger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
   - nightly
-
-matrix:
-  allow_failures:
-    - julia: 0.7
-    - julia: nightly
 
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7-alpha
 
 IterTools
 StaticArrays 0.5.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
@@ -12,12 +10,12 @@ branches:
     - master
 #    - /release-.*/
 
-matrix:
-  allow_failures:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+# matrix:
+#   allow_failures:
+#     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+#     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+#     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+#     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 notifications:
   - provider: Email

--- a/src/faces.jl
+++ b/src/faces.jl
@@ -8,13 +8,11 @@ Base.eltype(::Type{OffsetInteger{O, T}}) where {O, T} = T
 Base.eltype(oi::OffsetInteger) = eltype(typeof(oi))
 
 # constructors and conversion
-convert(::Type{OffsetInteger{O1, T1}}, x::OffsetInteger{O2, T2}) where {O1, O2, T1 <: Integer, T2 <: Integer} =
-    OffsetInteger{O1, T1}(T2(x))
-convert(::Type{OffsetInteger{O}}, x::Integer) where {O} = convert(OffsetInteger{O, eltype(x)}, x)
-convert(::Type{OffsetInteger{O}}, x::OffsetInteger) where {O} = convert(OffsetInteger{O, eltype(x)}, x)
-convert(::Type{OffsetInteger{O, T}}, x::Integer) where {O, T <: Integer} = convert(OffsetInteger{O, T}, OneIndex{eltype(x)}(x))
+OffsetInteger{O1, T1}(x::OffsetInteger{O2, T2}) where {O1, O2, T1 <: Integer, T2 <: Integer} = OffsetInteger{O1, T1}(T2(x))
 
-convert(::Type{IT}, x::OffsetInteger{O, T}) where {IT <: Integer, O, T <: Integer} = IT(raw(x) + -O)
+OffsetInteger{O}(x::Integer) where {O} = OffsetInteger{O, eltype(x)}(x)
+OffsetInteger{O}(x::OffsetInteger) where {O} = OffsetInteger{O, eltype(x)}(x)
+(::Type{IT})(x::OffsetInteger{O, T}) where {IT <: Integer, O, T <: Integer} = IT(raw(x) + -O)
 
 Base.@pure pure_max(x1, x2) = x1 > x2 ? x1 : x2
 Base.promote_rule(::Type{T1}, ::Type{OffsetInteger{O, T2}}) where {T1 <: Integer, O, T2} = T1


### PR DESCRIPTION
Fixes a few more deprecation warnings on Julia v0.7. I also raised the minimum Julia version to v0.7-alpha to avoid accidentally breaking 0.6. 