### PR TITLE
added rotation to linesegment intersects if a linesegment is vertical…

### DIFF
--- a/src/lines.jl
+++ b/src/lines.jl
@@ -52,8 +52,6 @@ function intersects(a::LineSegment{Point{N,T}}, b::LineSegment{Point{N,T}}) wher
         v4 = rotation * v4
     end
 
-    @assert !(v1[1] == v2[1] || v3[1] == v4[1])
-
     a = det(MT(
         v1[1] - v2[1], v1[2] - v2[2],
         v3[1] - v4[1], v3[2] - v4[2]

--- a/src/lines.jl
+++ b/src/lines.jl
@@ -33,22 +33,23 @@ function intersects(a::LineSegment{Point{N,T}}, b::LineSegment{Point{N,T}}) wher
     # if a segment is vertical the linear algebra might have trouble
     # so we will rotate the segments such that neither is vertical
     dorotation = verticalA || verticalB 
+
     if dorotation
-      θ = T(0.0)  
-      if verticalA && verticalB
-        θ = T(π/4)
-      elseif verticalA || verticalB # obviously true, but make it clear
-        θ34 = -atan(v4[2] - v3[2], v4[1] - v3[1])
-        θ12 = -atan(v2[2] - v1[2], v2[1] - v1[1])
-        θ = verticalA ? θ34 : θ12
-        θ = abs(θ) == T(0) ? (θ12 + θ34)/2 : θ
-        θ = abs(θ) == T(pi) ? (θ12 + θ34)/2 : θ
-      end
-      rotation = MT(cos(θ), sin(θ), -sin(θ), cos(θ))
-      v1 = rotation * v1
-      v2 = rotation * v2
-      v3 = rotation * v3
-      v4 = rotation * v4
+        θ = T(0.0)
+        if verticalA && verticalB
+            θ = T(π/4)
+        elseif verticalA || verticalB # obviously true, but make it clear
+            θ34 = -atan(v4[2] - v3[2], v4[1] - v3[1])
+            θ12 = -atan(v2[2] - v1[2], v2[1] - v1[1])
+            θ = verticalA ? θ34 : θ12
+            θ = abs(θ) == T(0) ? (θ12 + θ34)/2 : θ
+            θ = abs(θ) == T(pi) ? (θ12 + θ34)/2 : θ
+        end
+        rotation = MT(cos(θ), sin(θ), -sin(θ), cos(θ))
+        v1 = rotation * v1
+        v2 = rotation * v2
+        v3 = rotation * v3
+        v4 = rotation * v4
     end
 
     @assert !(v1[1] == v2[1] || v3[1] == v4[1])
@@ -71,7 +72,7 @@ function intersects(a::LineSegment{Point{N,T}}, b::LineSegment{Point{N,T}}) wher
    
     # don't forget to rotate the answer back
     if dorotation
-      (x, y) = transpose(rotation)*[x, y]
+        (x, y) = transpose(rotation)*[x, y]
     end
     return true, Point{N,T}(x, y)
 end

--- a/test/lines.jl
+++ b/test/lines.jl
@@ -25,11 +25,15 @@
     end
 
     @testset "linesegment intersect: #133" begin
-      s1 = LineSegment(Point{2,Float64}[[0.88033, 1.28211], [3.525, 1.28211]]...)
-      s2 = LineSegment(Point{2,Float64}[[2.0375, 1.1625], [2.0375, 1.2875]]...)
-      result = GeometryTypes.intersects(s1, s2)
-      @test result[1] == true
-      @test result[2] ≈ Point(2.0375, 1.28211)
+        s1 = LineSegment(Point{2,Float64}[[0.88033, 1.28211], [3.525, 1.28211]]...)
+        s2 = LineSegment(Point{2,Float64}[[2.0375, 1.1625], [2.0375, 1.2875]]...)
+        s1_old = deepcopy(s1)
+        s2_old = deepcopy(s2)
+        result = GeometryTypes.intersects(s1, s2)
+        @test s1 == s1_old # make sure it doesn't mutate inputs
+        @test s2 == s2_old # make sure it doesn't mutate inputs
+        @test result[1] == true
+        @test result[2] ≈ Point(2.0375, 1.28211)
     end
 
     @testset "poly self intersections" begin

--- a/test/lines.jl
+++ b/test/lines.jl
@@ -3,10 +3,13 @@
     @testset "linesegment intersect" begin
         a = LineSegment(Point2f0(0,0), Point2f0(1,0))
         b = LineSegment(Point2f0(0.5,0.5), Point2f0(0.5,-0.5))
-        @test intersects(a,b) == (true, Point2f0(0.5,0.0))
+        result = intersects(a,b) 
+        @test result[1] == true
+        @test result[2] ≈ Point2f0(0.5,0.0)
 
         a = LineSegment(Point2f0(0,0), Point2f0(0.499,0))
         b = LineSegment(Point2f0(0.5,0.5), Point2f0(0.5,-0.5))
+        result = intersects(a,b) 
         @test intersects(a,b) == (false, zero(Point2f0))
 
 
@@ -18,9 +21,17 @@
         @test p ≈ Point(9.34365, 11.0)
         intersect, p = intersects(l, r1)
         @test intersect
-        @test p == Point(9.0, 11.0)
-
+        @test p ≈ Point(9.0, 11.0)
     end
+
+    @testset "linesegment intersect: #133" begin
+      s1 = LineSegment(Point{2,Float64}[[0.88033, 1.28211], [3.525, 1.28211]]...)
+      s2 = LineSegment(Point{2,Float64}[[2.0375, 1.1625], [2.0375, 1.2875]]...)
+      result = GeometryTypes.intersects(s1, s2)
+      @test result[1] == true
+      @test result[2] ≈ Point(2.0375, 1.28211)
+    end
+
     @testset "poly self intersections" begin
         p1 = Point2f0[(x, sin(x)) for x in 0:.5:6]
         p2 = Point2f0[(p1[i][1], 0) for i=length(p1):-1:1]


### PR DESCRIPTION
…, which can mess up the linear algebra

#133 occurs because the matrix becomes singular with vertical lines. The solution implemented here is to rotate the line segements so that neither is vertical, then do the intersection calculation, and then rotation back.