### PR TITLE
Fixed inconsistency between extrema and minimum/maximum

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -170,10 +170,10 @@ function Base.extrema(a::AbstractVector{T}) where T <: FixedVector
     reduce((x, v)-> (min.(x[1], v), max.(x[2], v)), a; init = (T(typemax(ET)), T(typemin(ET))))
 end
 function Base.minimum(a::AbstractVector{T}) where T <: FixedVector
-    reduce((x, v)-> min.(x[1], v), a; init=T(typemax(eltype(T))))
+    reduce((x, v)-> min.(x, v), a; init=T(typemax(eltype(T))))
 end
 function Base.maximum(a::AbstractVector{T}) where T <: FixedVector
-    reduce((x, v)-> max.(x[1], v), a; init=T(typemin(eltype(T))))
+    reduce((x, v)-> max.(x, v), a; init=T(typemin(eltype(T))))
 end
 
 

--- a/test/baseutils.jl
+++ b/test/baseutils.jl
@@ -11,3 +11,21 @@
 
     @test_throws ArgumentError GeometryTypes.argmax(identity, [])
 end
+
+@testset "extrema" begin
+    xs = [GeometryTypes.Vec2f0(1f0, 1f0), GeometryTypes.Vec2f0(0.5f0, 1.5f0)]
+    extr = extrema(xs)
+
+    @test extr[1] ≈ GeometryTypes.Vec2f0(0.5f0, 1f0)
+    @test extr[2] ≈ GeometryTypes.Vec2f0(1f0, 1.5f0)
+
+    @testset "minimum" begin
+        val = minimum(xs)
+        @test val ≈ extr[1]
+    end
+
+    @testset "maximum" begin
+        val = maximum(xs)
+        @test val ≈ extr[2]
+    end
+end


### PR DESCRIPTION
Based on #174, makes `minimum(...)` behave consistently with `extrema(...)[1]` and `maximum(...)` with `extrema(...)[2]` (i.e. return the corner of the bounding box).