### PR TITLE
Fix cuboid face orientation

### DIFF
--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -188,11 +188,11 @@ function decompose(
         FT::Type{Face{N, T}}, rect::HyperRectangle{3, T2}
     ) where {N, T, T2}
     faces = Face{4, Int}[
-        (1,2,4,3),
+        (1,3,4,2),
         (2,4,8,6),
         (4,3,7,8),
-        (1,3,7,5),
-        (1,5,6,2),
+        (1,5,7,3),
+        (1,2,6,5),
         (5,6,8,7),
     ]
     decompose(FT, faces)

--- a/test/hyperrectangles.jl
+++ b/test/hyperrectangles.jl
@@ -223,4 +223,20 @@ end
     @test bb1 == bb2
 end
 
+@testset "face-orientation" begin
+    cube = HyperRectangle(Vec3f0(-0.5), Vec3f0(1))
+
+    cube_faces = decompose(Face{3,Int32}, cube)
+    cube_vertices = decompose(Point{3,Float32}, cube)
+
+    cube_tris = [cube_vertices[f] for f in cube_faces]
+
+    normals = [cross(t[2] - t[1], t[3] - t[1]) for t in cube_tris]
+    centroids = sum.(cube_tris) ./ 3f0
+
+    for (p, n) in zip(centroids, normals)
+        @test (p ⋅ n) > 0f0
+    end
+end
+
 end


### PR DESCRIPTION
Currently, the faces obtained by `decompose(Face, HyperRectangle{3})` are oriented towards the positive coordinate axes (assuming counter-clockwise winding order).

Since they enclose a volume, it would however make more sense if they pointed outwards (which would help with e.g. #144 or rendering with backface-culling enabled).

This PR thus fixes the orientation of the faces and adds a test to document this.