### PR TITLE
Make vertices(::Simplex) return an SVector

### DIFF
--- a/src/baseutils.jl
+++ b/src/baseutils.jl
@@ -6,7 +6,7 @@ deleteat{N,T,i}(x::NTuple{N,T}, ::Type{Val{i}})
 
 Return copy of x with ith entry ommited.
 """
-@generated function deleteat(x::NTuple{N,T}, ::Type{Val{i}}) where {N,T,i}
+@generated function deleteat(x::Union{NTuple{N,T},SVector{N,T}}, ::Type{Val{i}}) where {N,T,i}
     (1 <= i <= N) || throw(MethodError(drop_index, (x,Val{i})))
     args = [:(x[$j]) for j in deleteat!([1:N...], i)]
     Expr(:tuple, args...)
@@ -15,7 +15,7 @@ end
 """
 deleteat{N,T}(x::NTuple{N,T}, i::Int)
 """
-@generated deleteat(x::NTuple{N,T}, i::Int) where {N,T} = quote
+@generated deleteat(x::Union{NTuple{N,T},SVector{N,T}}, i::Int) where {N,T} = quote
     # would be nice to eliminate boundscheck
     (1 <= i <= N) || throw(BoundsError(x,i))
     @nif $(N) d->(i==d) d-> deleteat(x, Val{d})

--- a/src/convexhulls.jl
+++ b/src/convexhulls.jl
@@ -18,7 +18,7 @@ Base.copy(fl::FG) where {FG <: AFG} = FG(copy(vertices(fl)))
 push(fl::AFG, pt) = push!(copy(fl), pt)
 
 vertices(x::AbstractFlexibleGeometry) = x.vertices
-vertices(s::Simplex) = Tuple(s)
+vertices(s::Simplex) = SVector(s)
 
 standard_cube_vertices(::Type{Val{1}}) = [Vec(0), Vec(1)]
 _vcat(v1,v2) = Vec(Tuple(v1)..., Tuple(v2)...)

--- a/src/convexhulls.jl
+++ b/src/convexhulls.jl
@@ -61,7 +61,7 @@ vertexmat(s) = hcat(vertices(s)...)
 vertexmatrix(s::AbstractConvexHull) = Matrix(vertexmat(s))::Matrix{numtype(s)}
 
 (::Type{F})(g::Union{AbstractSimplex, AFG, GeometryPrimitive}) where {F <: AFG} = F(vertices(g))
-(::Type{F})(v::NTuple) where {F <: AFG} = F(collect(v))
+(::Type{F})(v::Union{NTuple,StaticArray}) where {F <: AFG} = F(collect(v))
 Base.convert(::Type{F}, s::Simplex) where {F <: AFG} = F(s)
 
 (::Type{R})(c::HyperCube) where {R <: HyperRectangle} = R(origin(c), widths(c))

--- a/src/convexhulls.jl
+++ b/src/convexhulls.jl
@@ -57,7 +57,7 @@ end
 
 vertices(c::HyperCube) = vertices(convert(HyperRectangle, c))
 
-vertexmat(s) = hcat(vertices(s)...)
+vertexmat(s) = hcat(Tuple(vertices(s))...)
 vertexmatrix(s::AbstractConvexHull) = Matrix(vertexmat(s))::Matrix{numtype(s)}
 
 (::Type{F})(g::Union{AbstractSimplex, AFG, GeometryPrimitive}) where {F <: AFG} = F(vertices(g))


### PR DESCRIPTION
As noted in #127, all other variants of `vertices` return something `<: AbstractVector`.

To avoid runtime overhead, this PR uses an SVector to conform to that interface. Additionally, a Simplex can now be constructed from an SVector, `deleteat` has been extended to support `SVectors` and a type instability that occurred when calling `vertexmat` with an SVector has been fixed.