### PR TITLE
Hash OffsetIntegers like the values they represent

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -80,6 +80,7 @@ raw(x::OffsetInteger) = x.i
 raw(x::Integer) = x
 value(x::OffsetInteger{O, T}) where {O, T} = raw(x) - O
 value(x::Integer) = x
+hash(x::OffsetInteger, h::UInt) = hash(value(x), h)
 
 """
 A `HyperRectangle` is a generalization of a rectangle into N-dimensions.


### PR DESCRIPTION
Useful for `unique`, `intersect`, etc on Arrays of `OffsetInteger`s or, for example, to compare `Face`s

(Potentially a better solution would be through automatic type promotion? The result would be the same hash however.)