### PR TITLE
update compat for ColorTypes, bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeometryTypes"
 uuid = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
 author = "Simon Danisch"
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -10,7 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ColorTypes = "0.8, 0.9, 0.10"
+ColorTypes = "0.8, 0.9, 0.10, 0.11"
 FixedPointNumbers = "0.5, 0.6, 0.7, 0.8"
 StaticArrays = "0.10, 0.11, 0.12, 1.0"
 julia = "1"


### PR DESCRIPTION
ColorTypes.jl released another version.
StaticArrays.jl released a few more versions; the prior spec ".., 1.0" should cover them.